### PR TITLE
Support for multiplexing several hosts over a single TLS connection

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -81,6 +81,10 @@ Link and route defs take optional arguments.
 
 	sets the cost of the route: `direct`, `ether`, `asynch`. (Should support actual numbers too?)
 
+- `mux` *%o-list*
+
+	For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (see `CHTLS_MAXMUX`).
+
 ### LINKTYPE:
 
 For links, you need to specify what link layer implementation is used for it.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -84,7 +84,7 @@ Link and route defs take optional arguments.
 - `mux` *%o-list*
 
     For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (see `CHTLS_MAXMUX`).
-    **NOTE** that the "muxed" addresses *must* be on the same subnet as the TLS link, and *each* must have individual links (directly reachable), defined *before* the TLS link.
+    **NOTE** that the "muxed" addresses *must* be on the same subnet as the TLS link, and *each* must be directly reachable through (individual) links, defined *before* the TLS link. *Note*: If the link to the muxed address is a `subnet` link (rather than a `host` link), routing might break.
 
 ### LINKTYPE:
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -83,7 +83,7 @@ Link and route defs take optional arguments.
 
 - `mux` *%o-list*
 
-    For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (see `CHTLS_MAXMUX`).
+    For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (currently 4, see `CHTLS_MAXMUX`).
     **NOTE** that the "muxed" addresses *must* be on the same subnet as the TLS link, and *each* must be directly reachable through (individual) links, defined *before* the TLS link. *Note*: If the link to the muxed address is a `subnet` link (rather than a `host` link), routing might break.
 
 ### LINKTYPE:

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -83,7 +83,8 @@ Link and route defs take optional arguments.
 
 - `mux` *%o-list*
 
-	For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (see `CHTLS_MAXMUX`).
+    For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (see `CHTLS_MAXMUX`).
+    **NOTE** that the "muxed" addresses *must* be on the same subnet as the TLS link, and *each* must have individual links (directly reachable), defined *before* the TLS link.
 
 ### LINKTYPE:
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -29,6 +29,15 @@ need to configure ITS to use address 6002, see [here](https://github.com/PDP-10/
 
 If you only run the ITS system, over chudp, and do not use Chaosnet over Ethernet for other purposes, just skip the `link ether` line.
 
+### A single klh10 behind a TLS-connected cbridge
+
+If you run a single klh10 but want to connect to the global Chaosnet using TLS, you can get away without allocating a whole subnet for your local hosts, by using the `mux` parameter. In this example, the local klh10 has been given address 3172, and the cbridge has been given address 3171 on subnet 6.
+
+	; First define the link to my KLH10
+	link chudp my.klh10 host 3172 myaddr 3171
+	; Then define the link to the central, with the mux parameter
+	link tls router.chaosnet.net host 3040 myaddr 3171 mux 3072
+
 ## Example: linux/macOS
 
 If you just want to connect your linux or macOS system to the global Chaosnet, something like this cwould work. 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -42,10 +42,10 @@ For a ITS/klh10 running on the same host as cbridge, you can (similar to the abo
 
 For cbridge, you can use the following:
 
-	; FIRST define the link to my KLH10
-	link chudp localhost:42043 host 3172 myaddr 3171
-	; THEN define the link to the central, with the mux parameter
-	link tls router.chaosnet.net host 3040 myaddr 3171 mux 3072
+    ; FIRST define the link to my KLH10
+    link chudp localhost:42043 host 3172 myaddr 3171
+    ; THEN define the link to the central, with the mux parameter
+    link tls router.chaosnet.net host 3040 myaddr 3171 mux 3072
 
 (The "mux" setup works not only for a single klh10, but also up to four local hosts.)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4,7 +4,10 @@ Some examples of configurations.
 
 ## Example: klh10
 
-Assuming you run an ITS system (e.g. on klh10), and a local Chaosnet network over Ethernet, and you use subnet 14 (octal). In the example, you connect to the Global Chaosnet over chudp, and you have been assigned address 3171 for connecting to it (cf Routing Basics).
+A slightly complex, but general, example. See the next example for a simpler setup with a single klh10.
+
+The example assumes you run an ITS system (e.g. on klh10), and a local Chaosnet network over Ethernet, and you use subnet 14 (octal). 
+In this example, you connect to the Global Chaosnet over chudp, and you have been assigned address 3171 for connecting to it (cf Routing Basics).
 
     ; My default Chaosnet address
     chaddr 6001
@@ -29,14 +32,22 @@ need to configure ITS to use address 6002, see [here](https://github.com/PDP-10/
 
 If you only run the ITS system, over chudp, and do not use Chaosnet over Ethernet for other purposes, just skip the `link ether` line.
 
-### A single klh10 behind a TLS-connected cbridge
+## Example: A single klh10 behind a TLS-connected cbridge
 
 If you run a single klh10 but want to connect to the global Chaosnet using TLS, you can get away without allocating a whole subnet for your local hosts, by using the `mux` parameter. In this example, the local klh10 has been given address 3172, and the cbridge has been given address 3171 on subnet 6.
 
-	; First define the link to my KLH10
-	link chudp my.klh10 host 3172 myaddr 3171
-	; Then define the link to the central, with the mux parameter
+For a ITS/klh10 running on the same host as cbridge, you can (similar to the above example) use
+
+    devdef chaos ub3 ch11 addr=764140 br=6 vec=270 myaddr=3172 chudpport=42043 chip=3171/localhost:42042
+
+For cbridge, you can use the following:
+
+	; FIRST define the link to my KLH10
+	link chudp localhost:42043 host 3172 myaddr 3171
+	; THEN define the link to the central, with the mux parameter
 	link tls router.chaosnet.net host 3040 myaddr 3171 mux 3072
+
+(The "mux" setup works not only for a single klh10, but also up to four local hosts.)
 
 ## Example: linux/macOS
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -40,8 +40,10 @@ For a ITS/klh10 running on the same host as cbridge, you can (similar to the abo
 
     devdef chaos ub3 ch11 addr=764140 br=6 vec=270 myaddr=3172 chudpport=42043 chip=3171/localhost:42042
 
-For cbridge, you can use the following:
+For cbridge, you can use the following (after [getting yourself a cerificate](TLS.md)):
 
+	; Configure my TLS key and cert (see TLS.md)
+	tls key private/my.key.pem cert certs/my.cert.pem
     ; FIRST define the link to my KLH10
     link chudp localhost:42043 host 3172 myaddr 3171
     ; THEN define the link to the central, with the mux parameter

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ It also implements the transport layer of Chaosnet (using any of the above link 
 You can configure the bridge to connect subnets and/or individual hosts. 
 
 Use cases could be
+- connecting ITSes running on klh10. Rather than configuring your
+  klh10 to handle all other chudp hosts and iptables to forward chudp
+  pkts over the tun interface, keep routing in the bridge
+  program. Adding new chudp hosts now doesn't require klh10
+  configuration. 
 - connecting remote Chaosnet-over-Ethernets, e.g. to communicate with
   others using LambdaDelta (use a Chaos-over-UDP or -over-TLS or -over-IP
   link between them). 
@@ -31,11 +36,6 @@ Use cases could be
   -over-IP link between them). 
 - connecting remote Chaosnet-over-IP networks, e.g. in case you run a
   [PDP-10/X](http://www.fpgaretrocomputing.org/pdp10x/).
-- connecting ITSes running on klh10 - rather than configuring your
-  klh10 to handle all other chudp hosts and iptables to forward chudp
-  pkts over the tun interface, keep routing in the bridge
-  program. Adding new chudp hosts now doesn't require klh10
-  configuration. 
 - and interconnecting these, of course!
 
 There is also support for connecting user programs such as Supdup (in some Unix-like environment) to Chaosnet - [read more](#network-control-program).

--- a/cbridge.c
+++ b/cbridge.c
@@ -1592,10 +1592,16 @@ parse_link_config()
 	}
       }
       if (!found) {
-	fprintf(stderr,"Error: muxed address %o not directly reachable through other host link\n", rt->rt_tls_muxed[i]);
-	return -1;
+	if ((rttbl_net[rt->rt_tls_muxed[i]>>8].rt_link != RT_NOLINK) && RT_DIRECT(&rttbl_net[rt->rt_tls_muxed[i]>>8])) {
+	  fprintf(stderr,"%%%% Warning: using a subnet link for a mux address (%o) might break routing\n", rt->rt_tls_muxed[i]);
+	  // look for next mux address
+	  found = 0;
+	} else {
+	  fprintf(stderr,"Error: muxed address %o not directly reachable through another link\n", rt->rt_tls_muxed[i]);
+	  return -1;
+	}
       } else
-	found = 0;
+	found = 0;		// look for next mux address
     }
     if ((addr >> 8) != (rt->rt_myaddr >> 8)) {
       fprintf(stderr,"Error: TLS destination address %o must be on same subnet as TLS \"myaddr\" %o\n",

--- a/cbridge.h
+++ b/cbridge.h
@@ -145,6 +145,11 @@ struct chroute {
   linktype_t rt_link;		/* link implementation */
   u_short rt_cost;		/* cost */
   time_t rt_cost_updated;	/* cost last updated */
+#if CHAOS_TLS
+// Number of addresses we can multiplex on a connection
+#define CHTLS_MAXMUX 4
+  u_short rt_tls_muxed[CHTLS_MAXMUX]; /* Other addresses we're muxing for */
+#endif
 };
 #define RT_BRIDGED(rt) ((rt)->rt_braddr != 0)
 #define RT_DIRECT(rt) ((rt)->rt_braddr == 0)
@@ -208,6 +213,7 @@ struct tls_dest {
   pthread_cond_t tcp_reconnect_cond;
   int tls_sock;			/* TCP socket */
   SSL *tls_ssl;			/* SSL conn */
+  u_short tls_muxed[CHTLS_MAXMUX]; /* See above: Other addresses we're muxing for */
 };
 
 // TLS stuff

--- a/chtls.c
+++ b/chtls.c
@@ -114,19 +114,19 @@ send_empty_sns(struct tls_dest *td, u_short onbehalfof)
   u_short src = td->tls_myaddr > 0 ? td->tls_myaddr : (tls_myaddr > 0 ? tls_myaddr : mychaddr[0]);  // default
   u_short dst = td->tls_addr;
   int i;
-  if (onbehalfof != 0)
-    src = onbehalfof;
 
   struct chroute *rt = find_in_routing_table(dst, 1, 0);
   if (rt == NULL) {
     if (tls_debug) fprintf(stderr,"Can't send SNS to %#o - no route found!\n", dst);
     return;
+  } else if (onbehalfof != 0) {
+    src = onbehalfof;
   } else
     if (rt->rt_myaddr > 0)
       src = rt->rt_myaddr;
 
   if (verbose || debug || tls_debug) 
-    fprintf(stderr,"Sending SNS from %#o to %#o\n", src, dst);
+    fprintf(stderr,"Sending SNS from %#o (obh %#o) to %#o\n", src, onbehalfof, dst);
 
   memset(pkt, 0, sizeof(pkt));
   set_ch_opcode(ch, CHOP_SNS);
@@ -347,7 +347,16 @@ add_tls_route(int tindex, u_short srcaddr)
     if (tls_debug) fprintf(stderr,"TLS route addition updates tlsdest addr from %#o to %#o\n", tlsdest[tindex].tls_addr, srcaddr);
     tlsdest[tindex].tls_addr = srcaddr;
   }
-  else if ((tlsdest[tindex].tls_addr != 0) && (tlsdest[tindex].tls_addr != srcaddr)) {
+  else if (((tlsdest[tindex].tls_addr >> 8) == (srcaddr >> 8)) && (tlsdest[tindex].tls_addr != srcaddr)) {
+    // add multiplexed dest @@@@ maybe let this be configurable?
+    int j;
+    for (j = 0; j < CHTLS_MAXMUX && tlsdest[tindex].tls_muxed[j] != 0; j++);
+    if (j < CHTLS_MAXMUX) {
+      fprintf(stderr,"Adding %#o to mux list %d of tlsdest %d\n", srcaddr, j, tindex);
+      tlsdest[tindex].tls_muxed[j] = srcaddr;
+    } else
+      fprintf(stderr,"%%%% Warning: Can not add %#o to mux list of tlsdest %d - list full, increase CHTLS_MAXMUX?\n", srcaddr, tindex);
+  } else if ((tlsdest[tindex].tls_addr != 0) && (tlsdest[tindex].tls_addr != srcaddr)) {
     char ip[INET6_ADDRSTRLEN];
     fprintf(stderr,"%%%% TLS link %d %s (%s) chaos address already known (%#o) but route not found - NOT updating to %#o\n",
 	    tindex, tlsdest[tindex].tls_name, ip46_ntoa(&tlsdest[tindex].tls_sa.tls_saddr, ip, sizeof(ip)),
@@ -369,6 +378,8 @@ close_tlsdest(struct tls_dest *td)
     memset((void *)&td->tls_sa.tls_saddr, 0, sizeof(td->tls_sa.tls_saddr));
     // forget remote chaos addr
     td->tls_addr = 0;
+    // forget any mux list
+    memset((void *)&td->tls_muxed, 0, sizeof(td->tls_muxed));
   }
   if (td->tls_ssl != NULL) {
     SSL_free(td->tls_ssl);
@@ -790,6 +801,7 @@ static void tls_please_reopen_tcp(struct tls_dest *td, int inputp)
 	      td, chaddr, chaddr, inputp, td->tls_name);
       print_tlsdest_config();
     }
+    return;
   } else {
     PTLOCKN(linktab_lock,"linktab_lock");
     if (inputp)
@@ -801,10 +813,11 @@ static void tls_please_reopen_tcp(struct tls_dest *td, int inputp)
 
   if (td->tls_serverp) {
     // no signalling to do, just close/free stuff
-    close_tlsdest(td);    
-    PTLOCKN(rttbl_lock,"rttbl_lock");
-    // also disable routing entry
-    struct chroute *rt = find_in_routing_table(chaddr, 1, 1);
+    int i;
+    struct chroute *rt;
+    // disable routing entries
+    PTLOCKN(rttbl_lock, "rttbl_lock");
+    rt = find_in_routing_table(chaddr, 1, 1);
     if (rt != NULL) {
       if (rt->rt_type != RT_NOPATH)
 	rt->rt_cost_updated = time(NULL); // cost isn't updated, but keep track of state change
@@ -812,12 +825,18 @@ static void tls_please_reopen_tcp(struct tls_dest *td, int inputp)
     }
     else if (tls_debug) fprintf(stderr,"TLS please reopen: can't find route for %#o to disable!\n", td->tls_addr);
     // need to also disable network routes this is a bridge for
-    int i;
     for (i = 0; i < 0xff; i++) {
       if ((rttbl_net[i].rt_link == LINK_TLS) && (rttbl_net[i].rt_braddr == chaddr))
 	rttbl_net[i].rt_type = RT_NOPATH;
     }
+    // and multiplexed routes
+    for (i = 0; i < CHTLS_MAXMUX && td->tls_muxed[i] != 0; i++) {
+      if ((rt = find_in_routing_table(td->tls_muxed[i], 1, 1)) != NULL) {
+	rt->rt_type = RT_NOPATH;
+      }
+    }
     PTUNLOCKN(rttbl_lock,"rttbl_lock");
+    close_tlsdest(td);    
   } else {
     // let connector thread do the closing/freeing
     if (tls_debug)
@@ -934,7 +953,7 @@ static int tls_write_record(struct tls_dest *td, u_char *buf, int len)
   }
   else if (wrote != len+2)
     fprintf(stderr,"tcp_write_record: wrote %d bytes != %d\n", wrote, len+2);
-  else if (tls_debug)
+  else if (tls_debug > 1)
     fprintf(stderr,"TLS write record: sent %d bytes (reclen %d)\n", wrote, len);
   PTUNLOCKN(tlsdest_lock,"tlsdest_lock");
 
@@ -985,7 +1004,7 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
       fprintf(stderr,"TLS read record: MARK read (no data)\n");
     return 0;
   }
-  if (tls_debug)
+  if (tls_debug > 1)
     fprintf(stderr,"TLS read record: record len %d\n", rlen);
   if (rlen > blen) {
     fprintf(stderr,"TLS read record: record too long for buffer: %d > %d\n", rlen, blen);
@@ -1028,7 +1047,7 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
 	tls_please_reopen_tcp(td, 1);
 	return -1;
       }
-      if (tls_debug)
+      if (tls_debug > 1)
 	fprintf(stderr,"TLS read record: read %d more bytes\n", actual);
       if (actual == 0) {
 	tls_please_reopen_tcp(td, 1);
@@ -1038,7 +1057,7 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
     }
     actual = p;
   }
-  if (tls_debug)
+  if (tls_debug > 1)
     fprintf(stderr,"TLS read record: read %d bytes total\n", actual);
 
   return actual;
@@ -1222,8 +1241,8 @@ handle_tls_input(int tindex)
     close_tlsdest(&tlsdest[tindex]);
     return;
   }
-  if (tls_debug) fprintf(stderr,"TLS input %s: Using source addr from trailer: %#o\n",
-			 ch_opcode_name(ch_opcode(cha)), srcaddr);
+  if (tls_debug > 1) fprintf(stderr,"TLS input %s: Using source addr from trailer: %#o\n",
+			     ch_opcode_name(ch_opcode(cha)), srcaddr);
   int cks;
   if ((cks = ch_checksum((u_char *)&data, len)) != 0) {
     // "This can't possibly happen!" - really!
@@ -1238,13 +1257,23 @@ handle_tls_input(int tindex)
   }
 
   // find the route to where from
-  struct chroute *srcrt = find_in_routing_table(srcaddr, 0, 0);
+  if (serverp && (ch_opcode(cha) == CHOP_SNS) && (ch_srcindex(cha) == 0) && (ch_destindex(cha) == 0)
+      && (srcaddr != ch_srcaddr(cha)) && (srcaddr >> 8) == (ch_srcaddr(cha) >> 8)) {
+    if (tls_debug) print_tls_warning(tindex, cha, "Using header source");
+    srcaddr = ch_srcaddr(cha);
+  }
+  struct chroute *srcrt = find_in_routing_table(srcaddr, 1, 0);
 
   if (tls_debug && serverp && (ch_opcode(cha) == CHOP_SNS) && (ch_srcindex(cha) == 0) && (ch_destindex(cha) == 0)) {
     if (srcrt == NULL)
       print_tls_warning(tindex, cha, "NEW empty SNS");
     else
-      print_tls_warning(tindex, cha, "Empty SNS");
+      print_tls_warning(tindex, cha, "Empty SNS but host route exists");
+    if (srcrt != NULL) {
+      struct chroute *rt = srcrt;
+      fprintf(stderr,"Found host route to dest %#o: %s dest %#o %s bridge %#o myaddr %#o\n", srcaddr,
+			 rt_linkname(rt->rt_link), rt->rt_dest, rt_typename(rt->rt_type), rt->rt_braddr, rt->rt_myaddr);
+    }
   }
   // @@@@ use config for whether to allow switching link types
   if ((srcrt == NULL) || (srcrt->rt_link != LINK_TLS)) {
@@ -1348,7 +1377,7 @@ void * tls_input(void *v)
 	    if (tls_debug) fprintf(stderr,"%%%% tls_input: received pkt from unknown socket %d\n", j);
 	    continue;
 	  }
-	  if (tls_debug) fprintf(stderr,"TLS input: fd %d => tlsdest %d\n", j, tindex);
+	  if (tls_debug > 1) fprintf(stderr,"TLS input: fd %d => tlsdest %d\n", j, tindex);
 	  handle_tls_input(tindex);
  	}
       }
@@ -1356,6 +1385,17 @@ void * tls_input(void *v)
   }
 }
 
+
+static int
+is_in_mux_list(u_short addr, u_short *list)
+{
+  int i;
+  for (i = 0; i < CHTLS_MAXMUX && list[i] != 0; i++) {
+    if (list[i] == addr)
+      return 1;
+  }
+  return 0;
+}
 
 // @@@@ consider running this in a separate (perhaps ephemeral) thread,
 // since it might hang on output due to TCP/TLS communication (and the other end having issues)
@@ -1379,6 +1419,9 @@ forward_on_tls(struct chroute *rt, u_short schad, u_short dchad, struct chaos_he
 	/* route to dest */
 	|| 
 	(rt->rt_braddr == 0 && (tlsdest[i].tls_addr == rt->rt_dest))
+	||
+	// multiplexed
+	is_in_mux_list(dchad, &tlsdest[i].tls_muxed)
 	) {
       if (verbose || debug) fprintf(stderr,"Forward TLS to dest %#o over %#o (%s)\n", dchad, tlsdest[i].tls_addr, tlsdest[i].tls_name);
       td = &tlsdest[i];

--- a/chtls.c
+++ b/chtls.c
@@ -1410,19 +1410,20 @@ forward_on_tls(struct chroute *rt, u_short schad, u_short dchad, struct chaos_he
   struct tls_dest *td = NULL;
   PTLOCKN(tlsdest_lock,"tlsdest_lock");
   for (i = 0; i < tlsdest_len; i++) {
-    if (
-	/* direct link to destination */
-	(tlsdest[i].tls_addr == dchad)
-	/* route to bridge */
-	|| 
-	(tlsdest[i].tls_addr == rt->rt_braddr)
-	/* route to dest */
-	|| 
-	(rt->rt_braddr == 0 && (tlsdest[i].tls_addr == rt->rt_dest))
-	||
-	// multiplexed
-	is_in_mux_list(dchad, &tlsdest[i].tls_muxed)
-	) {
+    if ((tlsdest[i].tls_addr != 0) &&
+	(
+	 /* direct link to destination */
+	 (tlsdest[i].tls_addr == dchad)
+	 /* route to bridge */
+	 || 
+	 (tlsdest[i].tls_addr == rt->rt_braddr)
+	 /* route to dest */
+	 || 
+	 (rt->rt_braddr == 0 && (tlsdest[i].tls_addr == rt->rt_dest))
+	 ||
+	 // multiplexed
+	 is_in_mux_list(dchad, &tlsdest[i].tls_muxed)
+	 )) {
       if (verbose || debug) fprintf(stderr,"Forward TLS to dest %#o over %#o (%s)\n", dchad, tlsdest[i].tls_addr, tlsdest[i].tls_name);
       td = &tlsdest[i];
       break;

--- a/chtls.c
+++ b/chtls.c
@@ -352,7 +352,7 @@ add_tls_route(int tindex, u_short srcaddr)
     int j;
     for (j = 0; j < CHTLS_MAXMUX && tlsdest[tindex].tls_muxed[j] != 0; j++);
     if (j < CHTLS_MAXMUX) {
-      fprintf(stderr,"Adding %#o to mux list %d of tlsdest %d\n", srcaddr, j, tindex);
+      if (tls_debug) fprintf(stderr,"Adding %#o to mux list %d of tlsdest %d\n", srcaddr, j, tindex);
       tlsdest[tindex].tls_muxed[j] = srcaddr;
     } else
       fprintf(stderr,"%%%% Warning: Can not add %#o to mux list of tlsdest %d - list full, increase CHTLS_MAXMUX?\n", srcaddr, tindex);


### PR DESCRIPTION
This allows e.g. a klh10/ITS to join the global Chaosnet using TLS through a cbridge (which is most often preferrable) without allocating a whole subnet.