### PR TITLE
The destination address of a RUT packet must be zero

### DIFF
--- a/cbridge.c
+++ b/cbridge.c
@@ -1050,6 +1050,11 @@ void send_rut_pkt(struct chroute *rt, u_char *pkt, int c)
     if (debug) fprintf(stderr,"%%%% Not sending RUT on %s link to %#o\n",
 		       rt_typename(rt->rt_link), rt->rt_dest);
     return;			/* ignore */
+#if 1
+  default:
+    // Destination of RUT packets should always be 0
+    set_ch_destaddr(cha, 0);	/* broadcast */
+#else    
 #if CHAOS_ETHERP
   case LINK_ETHER:
     set_ch_destaddr(cha, 0);	/* broadcast */
@@ -1075,6 +1080,7 @@ void send_rut_pkt(struct chroute *rt, u_char *pkt, int c)
       // direct route
       set_ch_destaddr(cha, rt->rt_dest);
     break;
+#endif
   }
   PTLOCKN(linktab_lock,"linktab_lock");
   if (ch_destaddr(cha) == 0)

--- a/cbridge.c
+++ b/cbridge.c
@@ -1045,43 +1045,14 @@ void send_rut_pkt(struct chroute *rt, u_char *pkt, int c)
   // Update source address
   set_ch_srcaddr(cha, (mya == 0 ? mychaddr[0] : mya));
 
-  switch (rt->rt_link) {
-  case LINK_NOLINK:
+  if (rt->rt_link == LINK_NOLINK) {
     if (debug) fprintf(stderr,"%%%% Not sending RUT on %s link to %#o\n",
 		       rt_typename(rt->rt_link), rt->rt_dest);
     return;			/* ignore */
-#if 1
-  default:
-    // Destination of RUT packets should always be 0
-    set_ch_destaddr(cha, 0);	/* broadcast */
-#else    
-#if CHAOS_ETHERP
-  case LINK_ETHER:
-    set_ch_destaddr(cha, 0);	/* broadcast */
-    break;
-#endif // CHAOS_ETHERP
-  case LINK_UNIXSOCK:
-    if ((rt->rt_dest & 0xff) != 0)
-      set_ch_destaddr(cha, rt->rt_dest);  /* host */
-    else
-      set_ch_destaddr(cha, 0);	/* subnet (broadcast) - does chaosd handle this? */
-    break;
-#if CHAOS_TLS
-  case LINK_TLS: // fall through
-#endif
-#if CHAOS_IP
-  case LINK_IP: // fall through
-#endif
-  case LINK_CHUDP:
-    if ((rt->rt_dest & 0xff) == 0) {
-      // subnet route - send it to the bridge
-      set_ch_destaddr(cha, rt->rt_braddr);
-    } else
-      // direct route
-      set_ch_destaddr(cha, rt->rt_dest);
-    break;
-#endif
   }
+  // Destination of RUT packets should always be 0
+  set_ch_destaddr(cha, 0);	/* broadcast */
+
   PTLOCKN(linktab_lock,"linktab_lock");
   if (ch_destaddr(cha) == 0)
     linktab[rt->rt_dest >> 8].pkt_out++;

--- a/chether.c
+++ b/chether.c
@@ -1480,6 +1480,7 @@ forward_on_ether(struct chroute *rt, u_short schad, u_short dchad, struct chaos_
   for (i = 0; i < nchethdest; i++) {
     if (dchad == 0) {		/* broadcast */
       // If it's a BRD, send on all interfaces; otherwise only on the one matching the source (hmm)
+      // @@@@ should match the route, rather?
       if ((opc == CHOP_BRD) || ((schad & 0xff00) == chethdest[i].cheth_addr)) {
 	if (chether_debug || debug) fprintf(stderr,"Forward: Broadcasting on ether %s from %#o\n", chethdest[i].cheth_ifname, schad);
 	send_packet(&chethdest[i], chethdest[i].cheth_chfd, ETHERTYPE_CHAOS, eth_brd, ETHER_ADDR_LEN, data, dlen);

--- a/chip.c
+++ b/chip.c
@@ -650,7 +650,7 @@ try_forward_individual_dest(struct chroute *rt, u_short dchad, u_char *data, int
 {
   int i;
   for (i = 0; i < chipdest_len; i++) {
-    if ( // maybe check broadcast at some point
+    if ( // no special broadcast check needed
 	/* direct link */
 	(chipdest[i].chip_addr == dchad) 
 	||

--- a/chip.c
+++ b/chip.c
@@ -650,7 +650,7 @@ try_forward_individual_dest(struct chroute *rt, u_short dchad, u_char *data, int
 {
   int i;
   for (i = 0; i < chipdest_len; i++) {
-    if ( // no special broadcast check needed
+    if (
 	/* direct link */
 	(chipdest[i].chip_addr == dchad) 
 	||

--- a/chudp.c
+++ b/chudp.c
@@ -503,7 +503,7 @@ forward_on_chudp(struct chroute *rt, u_short schad, u_short dchad, struct chaos_
   PTLOCKN(chudp_lock,"chudp_lock");
   for (i = 0; (i < chudpdest_len) && !found; i++) {
     if (
-#if 0
+#if 0				// Not needed since the route checks are done
 	dchad == 0		/* broadcast: goes on all links */
 	|| 
 #endif

--- a/chudp.c
+++ b/chudp.c
@@ -503,10 +503,6 @@ forward_on_chudp(struct chroute *rt, u_short schad, u_short dchad, struct chaos_
   PTLOCKN(chudp_lock,"chudp_lock");
   for (i = 0; (i < chudpdest_len) && !found; i++) {
     if (
-#if 0				// Not needed since the route checks are done
-	dchad == 0		/* broadcast: goes on all links */
-	|| 
-#endif
 	/* direct link to destination */
 	(chudpdest[i].chu_addr == dchad)
 	/* route to bridge */

--- a/contacts.c
+++ b/contacts.c
@@ -108,11 +108,7 @@ make_routing_table_pkt(u_short dest, u_char *pkt, int pklen)
     }
   }
   PTUNLOCKN(rttbl_lock,"rttbl_lock");
-#if 0
-  set_ch_destaddr(cha, ((dest & 0xff) == 0) ? 0 : dest );  /* well... */
-#else
-  set_ch_destaddr(cha, 0);	/* well no, RUT pkts must be sent to dest 0 */
-#endif
+  set_ch_destaddr(cha, 0);	/* RUT pkts must be sent to dest 0 */
   set_ch_nbytes(cha,nroutes*4);
   if (ch_nbytes(cha) > 0)
     return ch_nbytes(cha)+CHAOS_HEADERSIZE;

--- a/contacts.c
+++ b/contacts.c
@@ -108,7 +108,11 @@ make_routing_table_pkt(u_short dest, u_char *pkt, int pklen)
     }
   }
   PTUNLOCKN(rttbl_lock,"rttbl_lock");
+#if 0
   set_ch_destaddr(cha, ((dest & 0xff) == 0) ? 0 : dest );  /* well... */
+#else
+  set_ch_destaddr(cha, 0);	/* well no, RUT pkts must be sent to dest 0 */
+#endif
   set_ch_nbytes(cha,nroutes*4);
   if (ch_nbytes(cha) > 0)
     return ch_nbytes(cha)+CHAOS_HEADERSIZE;


### PR DESCRIPTION
both by standard (https://chaosnet.net/amber.html#Routing) and because MINITS won't accept them otherwise (https://github.com/PDP-10/its/issues/2119).