### PR TITLE
Don't link in libresolv on FreeBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ endif
 # versions.
 ifeq ($(OS_NAME), FreeBSD)
 LIBRESOLV=
-LIBTHREAD=-lthr
 endif
 
 all: cbridge hostat finger

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ CFLAGS = -g
 endif
 
 LIBRESOLV=-lresolv
-LIBTHREAD=
 
 # For OpenBSD, do "pkg_add libbind"
 ifeq ($(OS_NAME), OpenBSD)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CFLAGS = -g
 endif
 
 LIBRESOLV=-lresolv
+LIBTHREAD=
 
 # For OpenBSD, do "pkg_add libbind"
 ifeq ($(OS_NAME), OpenBSD)
@@ -19,8 +20,11 @@ LIBRESOLV = -lbind
 endif
 
 # On FreeBSD, the resolver is in libc.
+# Need to link with -lthr to get thread-safe
+# versions.
 ifeq ($(OS_NAME), FreeBSD)
 LIBRESOLV=
+LIBTHREAD=-lthr
 endif
 
 all: cbridge hostat finger

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ LDFLAGS = -L/usr/local/lib/libbind
 LIBRESOLV = -lbind
 endif
 
+# On FreeBSD, the resolver is in libc.
+ifeq ($(OS_NAME), FreeBSD)
+LIBRESOLV=
+endif
+
 all: cbridge hostat finger
 
 OBJS = cbridge.o contacts.o usockets.o chtls.o chudp.o debug.o chether.o dns.o chip.o ncp.o pkqueue.o

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OBJS = cbridge.o contacts.o usockets.o chtls.o chudp.o debug.o chether.o dns.o c
 # -lssl and -lcrypto are needed only for TLS.
 # -lresolv needed only for dns.o (use -lbind for OpenBSD)
 cbridge: $(OBJS) chaosd.h cbridge-chaos.h chudp.h
-	$(CC) $(CFLAGS) $(LDFLAGS) -o cbridge $(OBJS) -lpthread -lssl -lcrypto $(LIBRESOLV)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o cbridge $(OBJS) -pthread -lssl -lcrypto $(LIBRESOLV)
 
 cbridge.o: cbridge.c cbridge.h cbridge-chaos.h 
 	$(CC) -c $(CFLAGS) -o $@ $<


### PR DESCRIPTION
On FreeBSD, there is no libresolv.  (Name resolution functions are in the standard C library.). The patched Makefile allows building on FreeBSD.

Tested on FreeBSD 13.2, also tested on MacOS 14.0 Sonoma to verify that nothing broke on that platform.