### PR TITLE
Better window and flow management

### DIFF
--- a/cbridge.c
+++ b/cbridge.c
@@ -330,6 +330,11 @@ int is_private_subnet(u_short subnet)
   return private_subnet[subnet];
 }
 
+int valid_opcode(int opc)
+{
+  return !((opc == 0) || ((opc > CHOP_BRD) && (opc < CHOP_DAT)));
+}
+
 void print_link_stats() 
 {
   int i;

--- a/cbridge.h
+++ b/cbridge.h
@@ -304,6 +304,7 @@ u_short find_my_closest_addr(u_short addr);
 void add_mychaddr(u_short addr);
 int valid_chaos_host_address(u_short addr);
 int is_private_subnet(u_short subnet);
+int valid_opcode(int opc);
 
 char *rt_linkname(u_char linktype);
 char *rt_typename(u_char type);

--- a/contacts.c
+++ b/contacts.c
@@ -427,12 +427,13 @@ handle_rfc(struct chaos_header *ch, u_char *data, int dlen)
   int i;
   char cname[CH_PK_MAX_DATALEN];
   int datalen = ch_nbytes(ch);
-  if (datalen > 488) {
+  if (datalen > CH_PK_MAX_DATALEN) {
     fprintf(stderr,"NCP (handle_rfc): Data too long (%d, dlen %d) in %s pkt from <%#o,%#x> to <%#o,%#x>\n",
 	    datalen, dlen, ch_opcode_name(ch_opcode(ch)), 
 	    ch_srcaddr(ch), ch_srcindex(ch), ch_destaddr(ch), ch_destindex(ch));
     return 0;
   }
+  get_packet_string(ch, (u_char *)cname, sizeof(cname));
   char *space = index(cname, ' ');
   if (space) *space = '\0'; // look only for contact name, not args
   if (debug) fprintf(stderr,"Looking for handler of \"%s\"\n", cname);

--- a/contacts.c
+++ b/contacts.c
@@ -427,13 +427,12 @@ handle_rfc(struct chaos_header *ch, u_char *data, int dlen)
   int i;
   char cname[CH_PK_MAX_DATALEN];
   int datalen = ch_nbytes(ch);
-  if (datalen > CH_PK_MAX_DATALEN) {
+  if (datalen > 488) {
     fprintf(stderr,"NCP (handle_rfc): Data too long (%d, dlen %d) in %s pkt from <%#o,%#x> to <%#o,%#x>\n",
 	    datalen, dlen, ch_opcode_name(ch_opcode(ch)), 
 	    ch_srcaddr(ch), ch_srcindex(ch), ch_destaddr(ch), ch_destindex(ch));
     return 0;
   }
-  get_packet_string(ch, (u_char *)cname, sizeof(cname));
   char *space = index(cname, ' ');
   if (space) *space = '\0'; // look only for contact name, not args
   if (debug) fprintf(stderr,"Looking for handler of \"%s\"\n", cname);

--- a/ncp.c
+++ b/ncp.c
@@ -466,8 +466,8 @@ make_named_socket(int socktype, char *path, conntype_t conntype)
   // 256 (SO_RCVBUF) and 2048 (SO_SNDBUF) minus 32 for overhead, 
   // but it seems SNDBUF min is 4608 and RCVBUF is 2304.
   if (conntype == CT_Packet) {
-    set_socket_buf(sock, SO_SNDBUF, (CH_PK_MAX_DATALEN + 4)+32);
-    set_socket_buf(sock, SO_RCVBUF, (CH_PK_MAX_DATALEN + 4)+32);
+    set_socket_buf(sock, SO_SNDBUF, PACKET_SOCKET_BUFFER_SIZE);
+    set_socket_buf(sock, SO_RCVBUF, PACKET_SOCKET_BUFFER_SIZE);
   }
 
   // no signal, just error, please!
@@ -2651,6 +2651,7 @@ retransmit_controlled_packets(struct conn *conn)
 	      set_ch_ackno(pkt, cs->pktnum_read_highest);
 	    cs->pktnum_acked = cs->pktnum_read_highest; // record the sent ack
 	    PTUNLOCKN(cs->conn_state_lock,"conn_state_lock");
+	    memset(tempkt, 0, sizeof(tempkt));
 	    memcpy(tempkt, (u_char *)pkt, pklen);
 	    if (ncp_debug) printf("NCP >>> local %#x retransmitting controlled pkt %#x (%s), ack %#x\n",
 				  conn->conn_lidx,

--- a/ncp.c
+++ b/ncp.c
@@ -2510,10 +2510,13 @@ retransmit_controlled_packets(struct conn *conn)
   discard_received_pkts_from_send_list(conn, cs->pktnum_sent_receipt); // receipt?
 #endif
   u_short tosend = cs->foreign_winsize;
-  u_short unacked = pktnum_diff(cs->pktnum_sent_receipt, cs->pktnum_sent_acked);
+  // These are "in the network" still
+  u_short unacked = pktnum_diff(cs->pktnum_sent_highest, cs->pktnum_sent_acked);
   // We have discarded (from send queue) up to receipt, but window is based on acks
-#if 1
+#if 0
   tosend = tosend-unacked;
+#else
+  tosend = cs->window_available;
 #endif
   // u_short tosend = pktnum_diff(cs->pktnum_sent_highest, cs->pktnum_sent_receipt);
   u_short initial_tosend = tosend;
@@ -2521,8 +2524,8 @@ retransmit_controlled_packets(struct conn *conn)
   PTLOCKN(cs->send_mutex,"send_mutex");
   if ((npkts = pkqueue_length(cs->send_pkts)) > 0) {
     if (ncp_debug) {
-      printf("Retransmit: winsz %d, unacked %d - to send %d (%d)\n",
-	     cs->foreign_winsize, unacked, cs->foreign_winsize-unacked, tosend);
+      printf("Retransmit: winsz %d, unacked %d - to send %d (%d) avail win %d\n",
+	     cs->foreign_winsize, unacked, cs->foreign_winsize-unacked, tosend, cs->window_available);
       print_conn("Retransmit:", conn, 1);
     }
     for (q = pkqueue_first_elem(cs->send_pkts); q != NULL; q = pkqueue_next_elem(q)) {
@@ -2582,6 +2585,8 @@ retransmit_controlled_packets(struct conn *conn)
 	}
       }
     }
+    if (ncp_debug && (nsent > 0))
+      printf("Retransmitted %d pkts\n", nsent);
   }
   if (ncp_debug && (nsent < initial_tosend) && (nsent != npkts)) {
     printf("Retransmitted %d controlled packets, expected %d (qlen %d), thread %p\n", 
@@ -2608,7 +2613,7 @@ send_packet_when_window_open(struct conn_state *cs, struct chaos_header *pkt, in
     if (ncp_debug > 1) printf("Want to send controlled pkt %#x, window now %d, q len %d\n", ch_packetno(pkt),
 			  cs->window_available, pkqueue_length(cs->send_pkts));
 
-#if 0 // Window is checked when adding to the send queue
+#if 1 // Window is checked when adding to the send queue
     if (cs->window_available == 0) { // Window full, don't send it
       if (ncp_debug) printf("%%%%%s: window full, not sending!\n", __func__);
       return 0;
@@ -2904,7 +2909,7 @@ update_window_available(struct conn_state *cs, u_short winz) {
   if (winz < in_air) {
     // This could happen, since we discarded from send queue up to receipt,
     // but send (in retransmit_controlled_packets) a full window. 
-    // But can be avoided by using (winsize - diff(receipt,acked)) in retransmit_controlled_packets?
+    // But can be avoided by using (winsize - diff(highest,acked)) in retransmit_controlled_packets.
     if (ncp_debug)
       fprintf(stderr,"%%%% NCP: window would become negative! winz %d, shigh %#x, rec %#x, ack %#x, in_air %d\n", 
 	      winz, cs->pktnum_sent_highest, receipt, acked, in_air);
@@ -2946,11 +2951,14 @@ packet_to_conn_stream_handler(struct conn *conn, struct chaos_header *ch)
     // we got an ack update
     if (pktnum_less(cs->pktnum_sent_acked, ch_ackno(ch))) {
       cs->pktnum_sent_acked = ch_ackno(ch);
+      update_window_available(cs, cs->foreign_winsize);
+#if 0
       // Ack implies receipt
       if (pktnum_less(cs->pktnum_sent_receipt, cs->pktnum_sent_acked))
 	cs->pktnum_sent_receipt = cs->pktnum_sent_acked;
       // clear out receipted pkts from send_pkts
       discard_received_pkts_from_send_list(conn, cs->pktnum_sent_receipt); // receipt?
+#endif
     }
   }
   if ((cs->time_last_received == 0) && (ch_opcode(ch) != CHOP_FWD)) {
@@ -2971,7 +2979,7 @@ packet_to_conn_stream_handler(struct conn *conn, struct chaos_header *ch)
     if (pktnum_less(cs->pktnum_sent_receipt, receipt))
       cs->pktnum_sent_receipt = receipt;
     // validate reasonable value
-    if (winz <= MAX_WINSIZE) {
+    if ((winz <= MAX_WINSIZE) && (winz != cs->foreign_winsize)) {
       // adjust window_available - also may broadcast on window_cond
       PTLOCKN(cs->window_mutex, "window_mutex");
       update_window_available(cs, winz);

--- a/ncp.h
+++ b/ncp.h
@@ -79,7 +79,8 @@ struct conn_state {
   u_short send_pkts_pktnum_highest; // highest controlled pkt nr on send list
   pthread_mutex_t send_mutex; // to tell network there are things to send
   pthread_cond_t send_cond;
-  u_short pktnum_sent_highest;	// last we actually transmitted
+  //u_short pktnum_sent_highest;	// last we actually transmitted
+#define pktnum_sent_highest send_pkts_pktnum_highest
   u_short pktnum_sent_acked;	// last we got ack for
   u_short pktnum_sent_receipt;	// last we got receipt for
   time_t time_last_received;	// for probing

--- a/ncp.h
+++ b/ncp.h
@@ -29,6 +29,9 @@
 // 1/30s in millisec
 #define RETRANSMIT_LOW_THRESHOLD 33
 
+// Unix packet socket buffer sizes. Try one packet + NCP header + 32 for overhead.
+#define PACKET_SOCKET_BUFFER_SIZE (CH_PK_MAX_DATALEN + 4 + 32)
+
 // Conn types
 typedef enum conntype {
   CT_Simple,			/* RFC-ANS type */

--- a/ncp.h
+++ b/ncp.h
@@ -26,6 +26,8 @@
 #define PROBE_INTERVAL 10 // s
 #define LONG_PROBE_INTERVAL 60 // s
 #define HOST_DOWN_INTERVAL 300 // s = 5 min
+// 1/30s in millisec
+#define THIRTIETH_SEC_IN_MS 33
 
 // Conn types
 typedef enum conntype {

--- a/ncp.h
+++ b/ncp.h
@@ -27,7 +27,7 @@
 #define LONG_PROBE_INTERVAL 60 // s
 #define HOST_DOWN_INTERVAL 300 // s = 5 min
 // 1/30s in millisec
-#define THIRTIETH_SEC_IN_MS 33
+#define RETRANSMIT_LOW_THRESHOLD 33
 
 // Conn types
 typedef enum conntype {

--- a/ncp.h
+++ b/ncp.h
@@ -81,8 +81,6 @@ struct conn_state {
   u_short send_pkts_pktnum_highest; // highest controlled pkt nr on send list
   pthread_mutex_t send_mutex; // to tell network there are things to send
   pthread_cond_t send_cond;
-  //u_short pktnum_sent_highest;	// last we actually transmitted
-#define pktnum_sent_highest send_pkts_pktnum_highest
   u_short pktnum_sent_acked;	// last we got ack for
   u_short pktnum_sent_receipt;	// last we got receipt for
   time_t time_last_received;	// for probing

--- a/pkqueue.c
+++ b/pkqueue.c
@@ -113,6 +113,7 @@ pkqueue_add(struct chaos_header *pkt, struct pkqueue *q)
     perror("malloc(pkt_elem)"); exit(1);
   }
   nl->pkt = pkt;
+  nl->transmitted = 0;
   nl->next = NULL;
 
   if (ql != NULL)
@@ -145,6 +146,7 @@ pkqueue_insert_by_packetno(struct chaos_header *pkt, struct pkqueue *q)
     perror("malloc(pkt_elem)"); exit(1);
   }
   nl->pkt = pkt;
+  nl->transmitted = 0;
   nl->next = NULL;
   if (q->first == NULL) {
     // optimization: see if q was empty
@@ -219,6 +221,22 @@ pkqueue_peek_first(struct pkqueue *q)
     return NULL;
   else
     return q->first->pkt;
+}
+int
+pkqueue_peek_first_transmitted_p(struct pkqueue *q)
+{
+  if ((q == NULL) || (q->first == NULL))
+    return 0;
+  else
+    return q->first->transmitted;
+}
+int 
+pkqueue_set_first_transmitted_p(struct pkqueue *q, int val)
+{
+  if ((q == NULL) || (q->first == NULL))
+    return 0;
+  else
+    return q->first->transmitted = val;
 }
 struct chaos_header *
 pkqueue_peek_last(struct pkqueue *q)

--- a/pkqueue.c
+++ b/pkqueue.c
@@ -108,7 +108,7 @@ free_pkqueue(struct pkqueue *q)
   free(q);
 }
 
-int // returns new length
+struct pkt_elem * // returns new elem
 pkqueue_add(struct chaos_header *pkt, struct pkqueue *q)
 {
   struct pkt_elem *ql = NULL, *nl;
@@ -149,7 +149,7 @@ pkqueue_add(struct chaos_header *pkt, struct pkqueue *q)
   int len = q->pkq_len;
   PTUNLOCKN(q->pkq_mutex,"pkq_mutex");
 
-  return len;
+  return nl;
 }
 int // returns some interesting number
 pkqueue_insert_by_packetno(struct chaos_header *pkt, struct pkqueue *q)

--- a/pkqueue.h
+++ b/pkqueue.h
@@ -20,6 +20,7 @@
 
 struct pkt_elem {
   struct chaos_header *pkt;
+  u_char transmitted;		// whether it has been transmitted at least once
   struct pkt_elem *next;
 };
 
@@ -37,6 +38,8 @@ int pkqueue_add(struct chaos_header *pkt, struct pkqueue *q);
 int pkqueue_insert_by_packetno(struct chaos_header *pkt, struct pkqueue *q);
 struct chaos_header *pkqueue_get_first(struct pkqueue *q);
 struct chaos_header *pkqueue_peek_first(struct pkqueue *q);
+int pkqueue_peek_first_transmitted_p(struct pkqueue *q);
+int pkqueue_set_first_transmitted_p(struct pkqueue *q, int val);
 struct chaos_header *pkqueue_peek_last(struct pkqueue *q);
 struct pkt_elem *pkqueue_first_elem(struct pkqueue *q);
 struct pkt_elem *pkqueue_next_elem(struct pkt_elem *e);

--- a/pkqueue.h
+++ b/pkqueue.h
@@ -35,7 +35,7 @@ struct pkqueue {
 void print_pkqueue(struct pkqueue *q);
 struct pkqueue *make_pkqueue(void);
 void free_pkqueue(struct pkqueue *q);
-int pkqueue_add(struct chaos_header *pkt, struct pkqueue *q);
+struct pkt_elem *pkqueue_add(struct chaos_header *pkt, struct pkqueue *q);
 int pkqueue_insert_by_packetno(struct chaos_header *pkt, struct pkqueue *q);
 struct chaos_header *pkqueue_get_first(struct pkqueue *q);
 struct chaos_header *pkqueue_peek_first(struct pkqueue *q);

--- a/pkqueue.h
+++ b/pkqueue.h
@@ -17,10 +17,11 @@
 // Packet queue implementation
 
 #include <pthread.h>
+#include <time.h>
 
 struct pkt_elem {
   struct chaos_header *pkt;
-  u_char transmitted;		// whether it has been transmitted at least once
+  struct timespec transmitted;		// when it was last transmitted
   struct pkt_elem *next;
 };
 
@@ -38,10 +39,11 @@ int pkqueue_add(struct chaos_header *pkt, struct pkqueue *q);
 int pkqueue_insert_by_packetno(struct chaos_header *pkt, struct pkqueue *q);
 struct chaos_header *pkqueue_get_first(struct pkqueue *q);
 struct chaos_header *pkqueue_peek_first(struct pkqueue *q);
-int pkqueue_peek_first_transmitted_p(struct pkqueue *q);
-int pkqueue_set_first_transmitted_p(struct pkqueue *q, int val);
+struct pkt_elem *pkqueue_peek_first_elem(struct pkqueue *q);
 struct chaos_header *pkqueue_peek_last(struct pkqueue *q);
 struct pkt_elem *pkqueue_first_elem(struct pkqueue *q);
 struct pkt_elem *pkqueue_next_elem(struct pkt_elem *e);
 struct chaos_header *pkqueue_elem_pkt(struct pkt_elem *e);
+struct timespec *pkqueue_elem_transmitted(struct pkt_elem *e);
+void set_pkqueue_elem_transmitted(struct pkt_elem *e, struct timespec *ts);
 int pkqueue_length(struct pkqueue *q);


### PR DESCRIPTION
- Send STS for each 1/3 windowful, to keep other end updated and improve flow
- Discard packets on the send queue correctly, based on receipt fields of STSes, and regular ACKs
- Keep better track of window when adding to the send queue (don't overrun the window)
- Improve retransmissions by implementing a "last sent" timestamp for packets on the send queue, and only retransmit packets "older" than 1/30 sec. 
- Respect the probe interval to avoid sending SNS too often.
- Send packets already when adding them to the send queue - don't wait for retransmission to handle them.
- Set low buffers for packet socket, to make the window matter more (default buffers are 8k for macOS, over 200k for linux). (This is fairly experimental, even for this program.)
- Allow [options] for LSN (as for RFC and BRD) but only for setting window size and retransmission time interval.

Also several smaller things.

The result is a much smoother flow, less load caused by retransmission "storms", less retransmissions, and better flexibility.