### PR TITLE
Implement CRL checking for TLS

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -37,7 +37,7 @@ Below, *%o* means an octal number, and square brackets [ ] are around optional p
 
 	set up for TLS using the private key in *keyfile*, the cert in *certfile*, and the CA trust chain in *ca-chain-cert-file*. If `server` is specified, a TLS server is started listening to *portnr* (default 42042, if at EOL). TLS servers are always "dynamic" in that they listen to connections from anywhere, but accept only those using certificates trusted by the CA trust chain. Server-end connections are added dynamically at runtime, and can not be pre-declared. The local address is set to the `myaddr` parameter, or the global `chaddr`. With debug on, prints some debug stuff.  `expirywarn` defaults to 90, the number of days before certificate expiry to start whining about it.
 	
-	The `crl` parameter specifies a Certificate Revocation List file, supplied by the CA you use. This is encouraged, in particular if you are running a TLS server. You will need to update it regularly (a warning is printed about this).
+	The `crl` parameter specifies a Certificate Revocation List file, supplied by the CA you use. This is encouraged, in particular if you are running a TLS server. You will need to update it regularly (a warning is printed about this). See the (TLS documentation)[TLS.md#certificate-revocation-list-crl] for more info.
 - `ether` [ `debug` off/on ]
 
 	With debug on, prints some debug stuff. (Note that interface names are now on link definitions.) 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -33,9 +33,11 @@ Below, *%o* means an octal number, and square brackets [ ] are around optional p
 - `chudp` *portnr* [`dynamic` \| `static` \| `ipv6` \| `debug` off/on ]
 
 	set my chudp portnr (default 42042). If `dynamic`, add new chudp links [dynamically](#dynamic-links-and-routes) when receiving pkts from unknown sources. With ipv6 option, listens to both v4 and v6 (enabled also by defining a chudp link where the host has an ipv6 addr). With debug on, prints some debug stuff. 
-- `tls` [ `key` *keyfile* ] [ `cert` *certfile* ] [ `ca-chain` *ca-chain-cert-file* ] [ `myaddr` *%o* ] [ `server` *portnr* ] [ `debug` off/on ] [ `expirywarn `*days* ]
+- `tls` [ `key` *keyfile* ] [ `cert` *certfile* ] [ `ca-chain` *ca-chain-cert-file* ] [ `myaddr` *%o* ] [ `server` *portnr* ] [ `debug` off/on ] [ `expirywarn `*days* ] [ `crl` *crlfile* ]
 
 	set up for TLS using the private key in *keyfile*, the cert in *certfile*, and the CA trust chain in *ca-chain-cert-file*. If `server` is specified, a TLS server is started listening to *portnr* (default 42042, if at EOL). TLS servers are always "dynamic" in that they listen to connections from anywhere, but accept only those using certificates trusted by the CA trust chain. Server-end connections are added dynamically at runtime, and can not be pre-declared. The local address is set to the `myaddr` parameter, or the global `chaddr`. With debug on, prints some debug stuff.  `expirywarn` defaults to 90, the number of days before certificate expiry to start whining about it.
+	
+	The `crl` parameter specifies a Certificate Revocation List file, supplied by the CA you use. This is encouraged, in particular if you are running a TLS server. You will need to update it regularly (a warning is printed about this).
 - `ether` [ `debug` off/on ]
 
 	With debug on, prints some debug stuff. (Note that interface names are now on link definitions.) 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -37,7 +37,7 @@ Below, *%o* means an octal number, and square brackets [ ] are around optional p
 
 	set up for TLS using the private key in *keyfile*, the cert in *certfile*, and the CA trust chain in *ca-chain-cert-file*. If `server` is specified, a TLS server is started listening to *portnr* (default 42042, if at EOL). TLS servers are always "dynamic" in that they listen to connections from anywhere, but accept only those using certificates trusted by the CA trust chain. Server-end connections are added dynamically at runtime, and can not be pre-declared. The local address is set to the `myaddr` parameter, or the global `chaddr`. With debug on, prints some debug stuff.  `expirywarn` defaults to 90, the number of days before certificate expiry to start whining about it.
 	
-	The `crl` parameter specifies a Certificate Revocation List file, supplied by the CA you use. This is encouraged, in particular if you are running a TLS server. You will need to update it regularly (a warning is printed about this). See the (TLS documentation)[TLS.md#certificate-revocation-list-crl] for more info.
+	The `crl` parameter specifies a Certificate Revocation List file, supplied by the CA you use. This is encouraged, in particular if you are running a TLS server. You will need to update it regularly (a warning is printed about this). See the [TLS documentation](TLS.md#certificate-revocation-list-crl) for more info.
 - `ether` [ `debug` off/on ]
 
 	With debug on, prints some debug stuff. (Note that interface names are now on link definitions.) 

--- a/TLS.md
+++ b/TLS.md
@@ -78,7 +78,7 @@ The CRL file lists certificates that have been revoked and are no longer valid. 
 
 The CRL file is read on each new connection to the TLS server. At startup, cbridge checks your own certificate against the CRL and warns if it has been revoked.
 
-To make it easier to keep the CRL file up-to-date, the [crl-update.sh](crl-update.sh) script can be used. It should be run periodically, e.g. every night, and downloads and installs a new CRL file (if there is a new version of it).
+To make it easier to keep the CRL file up-to-date, the [crl-update.sh](crl-update.sh) script can be used. It should be run periodically, e.g. every night, and downloads and installs a new CRL file (if there is a new version of it). Example files for running it nightly using systemctl are included (`cbridge-crl-update.timer` and `cbridge-crl-update.service`).
 
 The CRL Distribution Point is currently https://chaosnet.net/intermediate.crl.pem.
 

--- a/TLS.md
+++ b/TLS.md
@@ -83,7 +83,7 @@ To make it easier to keep the CRL file up-to-date, the [crl-update.sh](crl-updat
 The CRL Distribution Point is currently https://chaosnet.net/intermediate.crl.pem.
 
 
-Conceptually, cbridge could download the CRL file internally, but it turns out that the `openssl` library is far too hairy and buggy(!) for this to be implemented in a reasonable way. The script should be OK. (If you have insights about this, please let me know!)
+Conceptually, cbridge could download the CRL file internally, but it turns out that the OpenSSL library is far too hairy and buggy(!) for this to be implemented in a reasonable way. The script should be OK. (If you have insights about this, please let me know!)
 
 ### Why not OCSP
 

--- a/cbridge-crl-update.service
+++ b/cbridge-crl-update.service
@@ -1,0 +1,19 @@
+# Install in /etc/systemd/system together with the cbridge-crl-update.timer.
+# This service run by the cbridge-crl-update.timer
+# so it does NOT need to be enabled or started.
+[Unit]
+Description=Update Chaosnet CRL file
+Documentation=https://github.com/bictorv/chaosnet-bridge/blob/master/TLS.md
+Requires=network-online.target
+Wants=nss-lookup.target
+After=network-online.target
+After=nss-lookup.target
+
+[Service]
+# YOU NEED TO UPDATE THE PATHS HERE MANUALLY - note also the cbridge.conf parameter
+Type=simple
+WorkingDirectory=/home/pi/chaosnet-bridge/
+ExecStart=/home/pi/chaosnet-bridge/crl-update.sh /home/pi/chaosnet-bridge/cbridge.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/cbridge-crl-update.timer
+++ b/cbridge-crl-update.timer
@@ -1,0 +1,18 @@
+# Install this and cbridge-crl-update.service /etc/systemd/system, run
+# sudo systemctl daemon-reload
+# then to enable and run the timer (which runs the service),
+# sudo systemctl enable --now cbridge-crl-update.timer
+# Check status with systemctl status cbridge-crl-update.timer or systemctl list-timers.
+[Unit]
+Description=Nightly update of the Chaosnet CRL file
+Documentation=https://github.com/bictorv/chaosnet-bridge/blob/master/TLS.md
+Requires=network-online.target
+After=network-online.target
+
+[Timer]
+OnCalendar=daily
+AccuracySec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/cbridge.c
+++ b/cbridge.c
@@ -2162,13 +2162,13 @@ main(int argc, char *argv[])
   // Just a little user-friendly config validation
   if (do_tls || do_tls_server) {
     char *files[] = {tls_ca_file, tls_key_file, tls_cert_file, tls_crl_file };
-    char err[PATH_MAX + sizeof("cannot access ")+3];
+    char err[PATH_MAX + sizeof("%%%% cannot access ")+3];
     int i;
     for (i = 0; i < 4; i++) {
       if ((strlen(files[i]) > 0) && (access(files[i], R_OK) != 0)) {
-	sprintf(err,"cannot access \"%s\"",files[i]);
+	sprintf(err,"%%%% cannot access \"%s\"",files[i]);
 	perror(err);
-	printf(" configured for TLS keyfile \"%s\", certfile \"%s\", ca-chain \"%s\", crl \"%s\"\n",
+	fprintf(stderr,"%%%% configured for TLS keyfile \"%s\", certfile \"%s\", ca-chain \"%s\", crl \"%s\"\n",
 	       tls_key_file, tls_cert_file, tls_ca_file, tls_crl_file);
 #if 0
 	exit(1);

--- a/cbridge.c
+++ b/cbridge.c
@@ -1,4 +1,4 @@
-/* Copyright © 2005, 2017-2021 Björn Victor (bjorn@victor.se) */
+/* Copyright © 2005, 2017-2023 Björn Victor (bjorn@victor.se) */
 /*  Bridge program for various Chaosnet implementations. */
 /*
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/cbridge.c
+++ b/cbridge.c
@@ -134,6 +134,7 @@ static char *private_hosts_file = NULL;
 char tls_ca_file[PATH_MAX] = "ca-chain.cert.pem";  /* trust chain */
 char tls_key_file[PATH_MAX];	/* private key */
 char tls_cert_file[PATH_MAX];	/* certificate */
+char tls_crl_file[PATH_MAX];	/* certificate revocation list */
 // @@@@ should allow for different addrs on different ports/links. Punt for now.
 u_short tls_myaddr = 0;		/* my chaos address on TLS server links */
 int tls_server_port = 42042;
@@ -1981,7 +1982,8 @@ print_stats(int sig)
 #endif
 #if CHAOS_TLS
     if (do_tls || do_tls_server) {
-      printf("Using TLS myaddr %#o, keyfile %s, certfile %s, ca-chain %s\n", tls_myaddr, tls_key_file, tls_cert_file, tls_ca_file);
+      printf("Using TLS myaddr %#o, keyfile %s, certfile %s, ca-chain %s, crl %s\n", 
+	     tls_myaddr, tls_key_file, tls_cert_file, tls_ca_file, tls_crl_file);
       if (do_tls_server)
 	printf(" and starting TLS server at port %d (%s)\n", tls_server_port, do_tls_ipv6 ? "IPv6" : "IPv4");
     }
@@ -2159,14 +2161,15 @@ main(int argc, char *argv[])
 #if CHAOS_TLS
   // Just a little user-friendly config validation
   if (do_tls || do_tls_server) {
-    char *files[] = {tls_ca_file, tls_key_file, tls_cert_file };
+    char *files[] = {tls_ca_file, tls_key_file, tls_cert_file, tls_crl_file };
     char err[PATH_MAX + sizeof("cannot access ")+3];
     int i;
-    for (i = 0; i < 3; i++) {
-      if (access(files[i], R_OK) != 0) {
+    for (i = 0; i < 4; i++) {
+      if ((strlen(files[i]) > 0) && (access(files[i], R_OK) != 0)) {
 	sprintf(err,"cannot access \"%s\"",files[i]);
 	perror(err);
-	printf(" configured for TLS keyfile \"%s\", certfile \"%s\", ca-chain \"%s\"\n", tls_key_file, tls_cert_file, tls_ca_file);
+	printf(" configured for TLS keyfile \"%s\", certfile \"%s\", ca-chain \"%s\", crl \"%s\"\n",
+	       tls_key_file, tls_cert_file, tls_ca_file, tls_crl_file);
 #if 0
 	exit(1);
 #endif

--- a/chtls.c
+++ b/chtls.c
@@ -1534,7 +1534,7 @@ validate_cert_vs_crl(X509 *cert, char *fname)
     int days = days_until_expiry(nupdate);
     if (days < 2) {
       BIO *b = BIO_new_fp(stderr, BIO_NOCLOSE);
-      BIO_printf(b, "%%%% Warning: CRL file %s expire%s ", tls_crl_file, days < 0 ? "d" : "s");
+      BIO_printf(b, "%%%% Warning: CRL file %s should %s updated %s ", tls_crl_file, days < 0 ? "have been" : "be");
       ASN1_TIME_print(b, nupdate);
       BIO_printf(b, days < 0 ? " (%d days ago)" : " (in %d days)\n", days < 0 ? -days : days);
       BIO_free(b);

--- a/chtls.c
+++ b/chtls.c
@@ -1,4 +1,4 @@
-/* Copyright © 2005, 2017-2021 Björn Victor (bjorn@victor.se) */
+/* Copyright © 2005, 2017-2023 Björn Victor (bjorn@victor.se) */
 /*  Bridge program for various Chaosnet implementations. */
 /*
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 */
 
 #include "cbridge.h"
+#include <openssl/x509v3.h>
 
 // when to start warning about approaching cert expiry
 #define TLS_CERT_EXPIRY_WARNING_DAYS 90
@@ -24,6 +25,7 @@ extern u_short tls_myaddr;
 extern char tls_ca_file[];
 extern char tls_key_file[];
 extern char tls_cert_file[];
+extern char tls_crl_file[];
 extern int do_tls_ipv6;
 extern int do_tls_server;
 extern int tls_server_port;
@@ -51,6 +53,10 @@ parse_tls_config_line()
       tok = strtok(NULL, " \t\r\n");
       if (tok == NULL) { fprintf(stderr,"tls: no ca-chain file specified\n"); return -1; }
       strncpy(tls_ca_file, tok, PATH_MAX);
+    } else if (strncmp(tok,"crl",sizeof("crl")) == 0) {
+      tok = strtok(NULL, " \t\r\n");
+      if (tok == NULL) { fprintf(stderr,"tls: no crl file specified\n"); return -1; }
+      strncpy(tls_crl_file, tok, PATH_MAX);
     } else if (strcmp(tok,"expirywarn") == 0) {
       tok = strtok(NULL, " \t\r\n");
       if (tok == NULL) { fprintf(stderr,"tls: no value for expirywarn specified\n"); return -1; }
@@ -266,9 +272,42 @@ static void tls_configure_context(SSL_CTX *ctx)
       }
     // Make sure to verify the peer (both server and client)
     // Consider adding a callback to validate CN/subjectAltName?
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
     // go up to "higher level CA"
     SSL_CTX_set_verify_depth(ctx, 2);
+
+    // Set up for CRL checking
+    if (strlen(tls_crl_file) > 0) {
+      X509_STORE *store = SSL_CTX_get_cert_store(ctx);
+      FILE *crl_fd = fopen(tls_crl_file,"r");
+      if (crl_fd == NULL) {
+	fprintf(stderr,"%%%% Can not open CRL file %s\n", tls_crl_file);
+	perror("fopen");
+	return;
+      } 
+      // Read the crl data
+      X509_CRL *crl = PEM_read_X509_CRL(crl_fd, NULL, NULL, NULL);
+      fclose(crl_fd);
+      if (crl == NULL) {
+	fprintf(stderr,"%s: Failed to read CRL from file %s\n", __func__, tls_crl_file);
+	return;
+      }
+      if (X509_STORE_add_crl(store, crl) == 0) {
+	fprintf(stderr,"%%%% %s: Failed to add CRL to store\n", __func__);
+	ERR_print_errors_fp(stderr);
+	return;
+      }
+      // Verify the leaf cert against CRL
+      X509_STORE_set_flags(store, X509_V_FLAG_CRL_CHECK);
+      // Update the SSL CTX store
+      SSL_CTX_set_cert_store(ctx, store);
+      // Now set up the verification params
+      if (SSL_CTX_set_purpose(ctx, X509_PURPOSE_ANY) == 0) { // @@@@ sloppy: server or client, depending
+	fprintf(stderr,"%%%% %s: Failed to set purpose\n", __func__);
+	ERR_print_errors_fp(stderr);
+	return;
+      }
+    }
 }
 
 
@@ -581,7 +620,11 @@ static int tcp_bind_socket(int type, u_short port)
 static int tcp_client_connect(struct sockaddr *sin)
 {
   int sock, unlucky = 1, foo;
+  u_long ntimes = 0;
+  char ip[INET6_ADDRSTRLEN];
   
+  (void)ip46_ntoa(sin, ip, sizeof(ip));
+
   while (unlucky) {
     if (tls_debug) fprintf(stderr,"TCP connect: socket family %d (%s)\n",
 			   sin->sa_family,
@@ -591,10 +634,9 @@ static int tcp_client_connect(struct sockaddr *sin)
       perror("socket(tcp)");
       exit(1);
     }
-
+    
     if (tls_debug) {
-      char ip[INET6_ADDRSTRLEN];
-      fprintf(stderr,"TCP connect: connecting to %s port %d\n", ip46_ntoa(sin, ip, sizeof(ip)),
+      fprintf(stderr,"TCP connect: connecting to %s port %d\n", ip,
 	      ntohs((sin->sa_family == AF_INET
 		     ? ((struct sockaddr_in *)sin)->sin_port
 		     : ((struct sockaddr_in6 *)sin)->sin6_port)));
@@ -608,12 +650,21 @@ static int tcp_client_connect(struct sockaddr *sin)
       // back off and try again - the other end might be down
       if (tls_debug)
 	fprintf(stderr,"TCP connect: trying again in %d s\n", unlucky);
+      else if (ntimes == 3)
+	fprintf(stderr,"%%%% TLS: connection to %s failed %lu times, trying again in %d s\n", ip, ntimes, unlucky);
       if ((foo = sleep(unlucky)) != 0) {
 	fprintf(stderr,"TCP connect: sleep returned %d\n", foo);
       }
       // Backoff: increase sleep until 30s, then go back to 10s
       unlucky++;
-      if (unlucky > 30) unlucky /= 3;
+      ntimes++;
+      if (unlucky > 30) {
+	unlucky /= 3;
+	// This happens the first time after sleeping 465 seconds + connection timeouts
+	// then every 275 seconds + timeouts
+	fprintf(stderr,"%%%% TLS: connection to %s failed %lu times, but still retrying - is the server up?\n",
+		ip, ntimes);
+      }
       if (close(sock) < 0)
 	perror("close(tcp_client_connect)");
       continue;
@@ -624,7 +675,7 @@ static int tcp_client_connect(struct sockaddr *sin)
   // log stuff about the connection
   if (tls_debug) {
     char ip[INET6_ADDRSTRLEN];
-    fprintf(stderr,"TCP connect: connected to %s port %d\n", ip46_ntoa(sin, ip, sizeof(ip)),
+    fprintf(stderr,"TCP connect: connected to %s port %d\n", ip,
 	    ntohs((sin->sa_family == AF_INET
 		   ? ((struct sockaddr_in *)sin)->sin_port
 		   : ((struct sockaddr_in6 *)sin)->sin6_port)));
@@ -1066,11 +1117,19 @@ tls_server(void *v)
     }
     SSL_set_fd(ssl, tsock);
     int v = 0;
+    ERR_clear_error();		/* try to get the latest error below, not some old */
     if ((v = SSL_accept(ssl)) <= 0) {
       // this already catches verification - client end gets "SSL alert number 48"?
       int err = SSL_get_error(ssl, v);
       if (err != SSL_ERROR_SSL) {
 	if (tls_debug) ERR_print_errors_fp(stderr);
+      } else {
+	// @@@@ Experiment: what errors do we get in various situations?
+	int rr = ERR_get_error();
+	// Note: Applications should not make control flow decisions based on specific error codes.
+	int libno = ERR_GET_LIB(rr);
+	int rsn = ERR_GET_REASON(rr);
+	fprintf(stderr,"%%%% SSL error: lib %d, reason %d: %s\n", libno, rsn, ERR_error_string(rr, NULL));
       }
       close(tsock);
       SSL_free(ssl);
@@ -1089,6 +1148,7 @@ tls_server(void *v)
 	  close(tsock);
 	  continue;
 	}
+
 	u_char *client_cn = tls_get_cert_cn(ssl_client_cert);
 	u_short client_chaddr = 0;
 #if CHAOS_DNS
@@ -1126,6 +1186,15 @@ tls_server(void *v)
 	  continue;
 	}
 #endif
+	// Get serial
+	const ASN1_INTEGER *serialp = X509_get0_serialNumber(ssl_client_cert);
+	if (serialp != NULL) {
+	  u_long serial = ASN1_INTEGER_get(serialp);
+	  char ip[INET6_ADDRSTRLEN];
+	  // @@@@ only do this once per client/serial
+	  fprintf(stderr,"TLS client connecting: serial %6lX at IP %s, CN %s\n", serial, 
+		  ip46_ntoa((struct sockaddr *)&caddr, ip, sizeof(ip)), client_cn);
+	}
 	// create tlsdest, fill in stuff
 	add_server_tlsdest(client_cn, tsock, ssl, (struct sockaddr *)&caddr, clen, client_chaddr);
     } else {
@@ -1199,6 +1268,7 @@ handle_tls_input(int tindex)
   // verify it is on tls_myaddr subnet
   if ((srcaddr == 0) || ((srcaddr & 0xff00) != (tlsdest[tindex].tls_myaddr & 0xff00))) {
     if (tls_debug) print_tls_warning(tindex, cha, "hw source address not on my net");
+    else if (verbose) fprintf(stderr,"TLS: Hardware source address %#o is not on my net %#o\n", srcaddr, (tlsdest[tindex].tls_myaddr & 0xff00)>>8);
     PTLOCKN(linktab_lock,"linktab_lock");
     srcaddr = ch_srcaddr(cha);
     if (srcaddr > 0xff)
@@ -1212,7 +1282,7 @@ handle_tls_input(int tindex)
   int cks;
   if ((cks = ch_checksum((u_char *)&data, len)) != 0) {
     // "This can't possibly happen!" - really!
-    if (1 || tls_debug) print_tls_warning(tindex, cha, "bad checksum");
+    if (1 || tls_debug) print_tls_warning(tindex, cha, "BAD CHECKSUM");
     PTLOCKN(linktab_lock,"linktab_lock");
     srcaddr = ch_srcaddr(cha);
     if (srcaddr > 0xff)
@@ -1406,7 +1476,7 @@ forward_on_tls(struct chroute *rt, u_short schad, u_short dchad, struct chaos_he
 }
 
 static int
-days_until_expiry(ASN1_TIME *x)
+days_until_expiry(const ASN1_TIME *x)
 {
   // find out how many days until expiry
   ASN1_TIME *now;
@@ -1420,6 +1490,63 @@ days_until_expiry(ASN1_TIME *x)
     abort();
   }
   return days;
+}
+
+static int
+validate_cert_vs_crl(X509 *cert, char *fname)
+{
+  // Ideally, read the crl from the dist_point in the cert
+  FILE *f = fopen(tls_crl_file,"r");
+  if (f == NULL) {
+    perror("crl fopen");
+    return -1;
+  }
+  X509_CRL *crl = PEM_read_X509_CRL(f, NULL, NULL, NULL);
+  if (crl == NULL) {
+    perror("PEM_read_X509_CRL");
+    ERR_print_errors_fp(stderr);
+    fclose(f);
+    return -1;
+  }
+  
+  // Check if it should be updated
+  const ASN1_TIME *nupdate = X509_CRL_get0_nextUpdate(crl);
+  if (nupdate != NULL) {
+    int days = days_until_expiry(nupdate);
+    if (days < 2) {
+      BIO *b = BIO_new_fp(stderr, BIO_NOCLOSE);
+      BIO_printf(b, "%%%% Warning: CRL file %s expire%s ", tls_crl_file, days < 0 ? "d" : "s");
+      ASN1_TIME_print(b, nupdate);
+      BIO_printf(b, days < 0 ? " (%d days ago)" : " (in %d days)\n", days < 0 ? -days : days);
+      BIO_free(b);
+    }
+  }
+  X509_STORE *store = X509_STORE_new();
+  X509_STORE_CTX *ctx = X509_STORE_CTX_new();
+  // Why not validate the chain as well
+  if (X509_STORE_load_locations(store, tls_ca_file, NULL) == 0) {
+    perror("X509_STORE_load_locations");
+    ERR_print_errors_fp(stderr);
+    return -1;
+  }
+
+  // First set the flag for the store: verify the leaf cert only
+  X509_STORE_set_flags(store, X509_V_FLAG_CRL_CHECK);
+  // Use this CRL
+  X509_STORE_add_crl(store, crl);
+  // Init the ctx so it has the store and cert
+  X509_STORE_CTX_init(ctx, store, cert, NULL);
+  // We're verifying it to be a client cert
+  X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_SSL_CLIENT);
+
+  // Now check the cert!
+  int r = X509_verify_cert(ctx);
+  if (r != 1) {
+    int err = X509_STORE_CTX_get_error(ctx);
+    fprintf(stderr,"%%%% Warning: the cert %s faild verification: %s\n", fname, X509_verify_cert_error_string(err));
+    return err;
+  }
+  return X509_V_OK;
 }
 
 static int
@@ -1442,7 +1569,7 @@ validate_cert_file(char *fname)
   fclose(f);
 
   // Check approaching expiration
-  ASN1_TIME *notAfter = X509_get_notAfter(cert);
+  const ASN1_TIME *notAfter = X509_get0_notAfter(cert);
   if (notAfter == NULL) {
     fprintf(stderr,"%%%% TLS: can't find expiration of cert %s\n", fname);
     return -1;
@@ -1544,6 +1671,11 @@ validate_cert_file(char *fname)
     }
   }
 #endif // CHAOS_DNS
+  // Check that it hasn't been revoked
+  if (strlen(tls_crl_file) > 0) {
+    if (validate_cert_vs_crl(cert, fname) != 0)
+      return -1;
+  }
   return 0;
 }
 

--- a/crl-update.sh
+++ b/crl-update.sh
@@ -93,7 +93,7 @@ if [ -r $OUTPUT ]; then
 	mv $OUTPUT $INCRL.new
 	[ -r $INCRL ] && mv $INCRL $INCRL.old.$onum
 	mv $INCRL.new $INCRL
-	echo CRL file updated - new CRL number $num - please restart cbridge!
+	echo CRL file updated - new CRL number $num
     fi
 fi
     

--- a/crl-update.sh
+++ b/crl-update.sh
@@ -1,0 +1,100 @@
+#/bin/sh
+## Copyright © 2023 Björn Victor (bjorn@victor.se)
+## Script to fetch a fresh CRL file if needed. Run it periodically, e.g. every night.
+
+## arg: the cbridge.conf file
+# to use to find CRL file name, ca-bundle, and cert
+# If the crl file doesn't exist, (NYI: or it doesn't verify), (NYI: or if given a bootstrap URL),
+# unconditionally fetch a new crl file from the url,
+# otherwise fetch one if it is newer than the existing file.
+# (Don't compare to "last updated" property of CRL,
+# since the FILE at the distribution point most likely is always later.)
+
+INPUT=$1
+if [ "X$INPUT" == "X" ]; then
+    INPUT=./cbridge.conf
+fi
+if [ ! -r $INPUT ]; then
+    echo cbridge config file $INPUT not found
+    exit 1
+fi
+
+TLSCONF=$(grep -v '^;' $INPUT | grep ^tls)
+
+if [ "X$TLSCONF" == "X" ]; then
+    echo No TLS configuration found in $INPUT
+    exit 1
+fi
+
+INDIR=$(dirname $INPUT)
+
+INCRL=$INDIR/$(echo $TLSCONF | grep crl | sed -E 's/.* crl ([^ ]+)( .*)?/\1/' )
+CERT=$INDIR/$(echo $TLSCONF | grep cert | sed -E 's/.* cert ([^ ]+)( .*)?/\1/' )
+CABUNDLE=$(echo $TLSCONF | grep ca-chain | sed -E 's/.* ca-chain ([^ ]+)( .*)?/\1/' )
+if [ "X$CABUNDLE" == "X" ]; then
+    # Not found, use default name
+   CABUNDLE=ca-chain.cert.pem
+fi
+CABUNDLE=$INDIR/$CABUNDLE
+
+if [ "X$CERT" == "X" -o ! -r $CERT ]; then
+    echo Error: cert file $CERT not found
+    exit 1
+fi
+if [ ! -r $CABUNDLE ]; then
+    echo Error: CA bundle file not found
+    exit 1
+fi
+
+OUTPUT=/tmp/$(basename $INCRL)
+
+if [ -r $INCRL ]; then
+    next=$(openssl crl -in $INCRL -noout -nextupdate -dateopt iso_8601 | sed -e 's/.*=//')
+    last=$(openssl crl -in $INCRL -noout -lastupdate -dateopt iso_8601 | sed -e 's/.*=//')
+    # Needed for curl to parse it
+    # rlast=$(openssl crl -in $INCRL -noout -lastupdate -dateopt rfc_822 | sed -e 's/.*=//')
+    url=$(openssl crl -in $INCRL -noout -text | grep URI: | sed -e 's/.*URI://')
+
+    # echo CRL last updated $last, next $next, URL $url
+
+    if [ $(date +"%s") -ge $(date -j -f "%F %TZ" "$next" +"%s") ]; then
+	# Keep this script running and it shouldn't happen very often
+	echo WARNING: The CRL $INCRL has expired!
+    fi
+    # Fetch a new copy if it is newer
+    rm -f $OUTPUT
+    curl -S -s --time-cond $INCRL --output $OUTPUT $url
+else
+    echo CRL file $INCRL does not exist, fetching a fresh copy
+    # Find DP from $CERT
+    url=$(openssl x509 -in $CERT -noout -ext crlDistributionPoints | grep URI: | sed -e 's/.*URI://')
+    if [ "X$url" == "X" ]; then
+	# DP not found in cert (ok if it is old) - use default
+	url=https://chaosnet.net/intermediate.crl.pem
+    fi
+    rm -f $OUTPUT
+    curl -S -s --output $OUTPUT $url
+fi
+
+if [ -r $OUTPUT ]; then
+    # We got something, check if it is OK
+    if ! openssl crl -verify -noout -CAfile $CABUNDLE -in $OUTPUT 2>/dev/null; then
+	echo The fetched CRL file could not be verified:
+	# Now show the output
+	openssl crl -verify -noout -CAfile $CABUNDLE -in $OUTPUT
+	exit 1
+    fi
+    nnext=$(openssl crl -in $OUTPUT -noout -nextupdate -dateopt iso_8601 | sed -e 's/.*=//')
+    if [ $(date +"%s") -ge $(date -j -f "%F %TZ" "$nnext" +"%s") ]; then
+	echo ERROR: The fetched CRL has expired already!
+    else
+	num=$(openssl crl -in $OUTPUT -noout -crlnumber | sed -e 's/.*=//')
+	[ -r $INCRL ] && onum=$(openssl crl -in $INCRL -noout -crlnumber | sed -e 's/.*=//')
+	mv $OUTPUT $INCRL.new
+	[ -r $INCRL ] && mv $INCRL $INCRL.old.$onum
+	mv $INCRL.new $INCRL
+	echo CRL file updated - new CRL number $num - please restart cbridge!
+    fi
+fi
+    
+


### PR DESCRIPTION
The CRL file lists certificates that have been revoked and are no longer valid. To make sure those certificates are not accepted by Chaos-over-TLS servers, you can download the current CRL file and specify it using the `crl` option.

The CRL file is read on each new connection to the TLS server. At startup, cbridge checks your own certificate against the CRL and warns if it has been revoked.

To make it easier to keep the CRL file up-to-date, the [crl-update.sh](crl-update.sh) script can be used. It should be run periodically, e.g. every night, and downloads and installs a new CRL file (if there is a new version of it). Example files for running it nightly using systemctl are included (`cbridge-crl-update.timer` and `cbridge-crl-update.service`).

Conceptually, cbridge could download the CRL file internally, but it turns out that the OpenSSL library is far too hairy and buggy(!) for this to be implemented in a reasonable way. The script should be OK. (If you have insights about this, please let me know!)