### PR TITLE
Support for UNC packets

### DIFF
--- a/NCP.md
+++ b/NCP.md
@@ -196,7 +196,8 @@ followed by the *n* bytes of data of the packet, where *n* is the length indicat
 | ANS (rcvd) | *src* *data* | *src* is the source address (two bytes: LSB, MSB), followed by *data* which is the original binary data (not interpreted by NCP) |
 | ANS (sent) | *data* | binary data (not interpreted by NCP) |
 | LOS, CLS | *reason* | ascii (but not interpreted by NCP) |
-| DAT, DWD, UNC | *data*  | binary (not interpreted by NCP) |
+| UNC | *data* | binary, where the first 4 bytes are stored in the packetno and ackno fields of the header (each 2 bytes) |
+| DAT, DWD | *data*  | binary (not interpreted by NCP) |
 | EOF | none | or when sending, optionally the ascii string "wait" (four bytes) |
 | FWD | *addr* | LSB, MSB of forwarding address |
 | ACK | none | received from NCP as response to "EOF wait", when th EOF is acked or an eofwait timeout happens |
@@ -232,11 +233,12 @@ The NCP handles duplicates and flow control, and DAT and DWD packets are deliver
 By the way, the description of the bidirectional "safe EOF protocol" in [Section 4.4 of Chaosnet](https://chaosnet.net/amber.html#index-EOF) is not what is implemented in Lisp Machines or, it seems, in ITS.
 
 #### NOTE
-The data part of `RFC`, `OPN`, `ANS` and `FWD` packets are non-standard:
+The data part of `RFC`, `OPN`, `ANS`, `FWD`, and `UNC` packets are non-standard:
 - for RFC, it includes the remote host and (optional) options (see above).
 - for OPN (received), it includes the remote host (see above)
 - for ANS (received), it includes the remote host (see above)
 - for FWD, it is two bytes of host address [lsb, msb] (which gets put in the ack field of the actual packet).
+- for UNC, it includes the packetno (2 bytes) and ackno (2 bytes) fields, which are not used for their normal purposes, but by the protocol using UNC. See [Using Foreign Protocols in Chaosnet](https://chaosnet.net/amber.html#Using-Foreign-Protocols-in-Chaosnet), and for example the "screen SPY" protocol for LispM.
 
 #### NOTE further
 If an `EOF` packet sent from the user program to the NCP has the data "wait" (four bytes), the NCP will send the EOF packet (without data) on the Chaosnet, await the packet to be acked, and send a special `ACK` packet (opcode 0177) to the user program when either the EOF packet is acked, or the `eofwait` timeout occurs. 

--- a/NCP.md
+++ b/NCP.md
@@ -238,7 +238,7 @@ The data part of `RFC`, `OPN`, `ANS`, `FWD`, and `UNC` packets are non-standard:
 - for OPN (received), it includes the remote host (see above)
 - for ANS (received), it includes the remote host (see above)
 - for FWD, it is two bytes of host address [lsb, msb] (which gets put in the ack field of the actual packet).
-- for UNC, it includes the packetno (2 bytes) and ackno (2 bytes) fields, which are not used for their normal purposes, but by the protocol using UNC. See [Using Foreign Protocols in Chaosnet](https://chaosnet.net/amber.html#Using-Foreign-Protocols-in-Chaosnet), and for example the "screen SPY" protocol for LispM.
+- for UNC, it includes the packetno (2 bytes) and ackno (2 bytes) fields, which are not used for their normal purposes, but by the protocol using UNC. See [Using Foreign Protocols in Chaosnet](https://chaosnet.net/amber.html#Using-Foreign-Protocols-in-Chaosnet), and for example the "screen SPY" protocol for LispM (cf `spy.py` in this repo).
 
 #### NOTE further
 If an `EOF` packet sent from the user program to the NCP has the data "wait" (four bytes), the NCP will send the EOF packet (without data) on the Chaosnet, await the packet to be acked, and send a special `ACK` packet (opcode 0177) to the user program when either the EOF packet is acked, or the `eofwait` timeout occurs. 
@@ -246,6 +246,8 @@ If an `EOF` packet sent from the user program to the NCP has the data "wait" (fo
 This is sometimes necessary for complex protocols, such as [FILE](https://github.com/PDP-10/its/blob/master/doc/sysdoc/chaos.file).
 
 Note, again, that the data part of EOF is always empty when sent over Chaosnet, and that the ACK packet is never sent over Chaosnet - only between the NCP and the user program.
+
+Note also that `UNC` packets may be lost or out-of-order.
 
 # Internals
 

--- a/chaosnet.py
+++ b/chaosnet.py
@@ -177,6 +177,8 @@ class PacketConn(NCPConn):
         self.send_packet(Opcode.CLS, msg)
     def send_ans(self, msg):
         self.send_packet(Opcode.ANS, msg)
+    def send_unc(self, msg):
+        self.send_packet(Opcode.UNC, msg)
     def send_opn(self):
         self.send_packet(Opcode.OPN)
     def send_eof(self, wait=False):
@@ -204,6 +206,9 @@ class PacketConn(NCPConn):
         if opc == Opcode.ANS:
             # Includes 2 bytes of source!
             assert length <= 490
+        elif opc == Opcode.UNC:
+            # Includes 4 bytes (packetno, ackno fields)
+            assert length <= 492
         else:
             assert(length <= 488)
         if debug:

--- a/chaosnet.py
+++ b/chaosnet.py
@@ -537,7 +537,7 @@ import dns.resolver
 
 # Default DNS resolver for Chaosnet
 dns_resolver_name = 'DNS.Chaosnet.NET'
-dns_resolver_address = None
+dns_resolver_address = socket.gethostbyname(dns_resolver_name)
 
 def set_dns_resolver_address(adorname):
     global dns_resolver_address

--- a/ncp.c
+++ b/ncp.c
@@ -2438,6 +2438,9 @@ add_input_pkt(struct conn *c, struct chaos_header *pkt)
   // Only add uncontrolled pkts if they fit in the window, to avoid being flooded
   if (packet_uncontrolled(pkt) && (pkqueue_length(cs->read_pkts) >= cs->local_winsize)) {
     PTUNLOCKN(cs->read_mutex,"read_mutex");
+    PTLOCKN(linktab_lock,"linktab_lock");
+    linktab[ch_srcaddr(pkt)>>8].pkt_lost++; // count it as lost on reading
+    PTUNLOCKN(linktab_lock,"linktab_lock");
     return;
   }
     

--- a/spy.py
+++ b/spy.py
@@ -1,0 +1,115 @@
+# Copyright © 2024 Björn Victor (bjorn@victor.se)
+# Chaosnet client for SPY protocol, to see the screen of a LISPM.
+# Demonstrates the high-level python library for Chaosnet,
+# and use of UNC packets.
+
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# The SPY protocol is defined by the sources of the LISPM function:
+# - screen segments are packaged in UNC packets
+#   where the pktnum and ackno fields hold the width and height of the screen,
+#   and the first 16b word is the index for this packet into the screen.
+#
+# It is rather inefficient: it sends every part of the screen, whether it
+# has changed or not. It would be better to send only parts which have changed,
+# keeping track of that either by a screen copy or by hashing screen segments.
+# This would only require fixes on the server side (for CADR there are 191 segments).
+
+import sys, time, functools, math
+
+# see https://www.pygame.org/docs/
+import pygame
+
+from chaosnet import PacketConn, ChaosError, Opcode
+
+# pygame.PixelArray
+# https://www.pygame.org/docs/ref/pixelarray.html#pygame.PixelArray
+
+debug = False
+
+# How many words fit in a packet where 2 bytes are index?
+number_of_16b_words = int((488-2)/2)
+
+# Get a packet, handle it.
+# If width is not given, get it from the packet.
+# If pixelarray is not given, create a window and get it from there.
+def spy_process_packet(c, width=None, height=None, pix=None):
+    opc,data = c.get_packet()
+    if opc != Opcode.UNC:
+        raise UnexpectedOpcode("Bad opcode {}, expected UNC".format(Opcode(opc).name))
+    if width == None:
+        # Each packet contains this
+        width = data[0] | (data[1]<<8)
+        height = data[2] | (data[3]<<8)
+        if debug:
+            print("width {} height {}".format(width,height))
+    if pix == None:
+        # Create a window, and get a handle into it
+        pix = pygame.PixelArray(pygame.display.set_mode(size=(width,height)))
+    # The index into the screen for this packet
+    idx = data[4] | (data[5]<<8)
+    if debug:
+        print("idx {}".format(idx))
+    # number_of_16b_words in each pkt, 16 pixels in each word
+    spix = idx*number_of_16b_words*16 
+    epix = spix+number_of_16b_words*16
+    # convert b/w pixels to 0/255 values
+    pvals = []                            # use an array of 243 instead?
+    for b in data[6:]:
+        for i in range(8):
+            pvals.append(0xFFFFFF if b&(1<<i)==0 else 0)
+    if debug:
+        print("start row {}, start col {}".format(spix % width, math.floor((spix / width)%height)))
+    # @@@@ Do this more efficently, assign slices.
+    for p in range(len(pvals)):
+        try:
+            pix[(spix + p) % width, math.floor((spix + p)/width)%height] = pvals[p]
+        except IndexError as m:
+            print("{} at {},{}, pos {}".format(m,(spix + p) % width, math.floor((spix + p)/width)%height,p), file=sys.stderr)
+            raise
+    # Now update the window
+    pygame.display.flip()
+    return pix,width,height
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description="Spy on a LISPM screen using Chaosnet (if it allows you).")
+    parser.add_argument("-d",'--debug',dest='debug',action='store_true',
+                            help='Turn on debug printouts')
+    parser.add_argument("-n",'--numpkts',type=int,
+                            help='Only process the first N packets')
+    parser.add_argument("host", help='The host to spy on')
+    args = parser.parse_args()
+    if args.debug:
+       debug = True
+       print(args, file=sys.stderr)
+
+    try:
+        c = PacketConn()
+        c.set_debug(debug)
+        c.connect(args.host, "SPY")
+        w,h,pa = None, None, None
+        n = 0
+        while args.numpkts is None or n < args.numpkts:
+            pa,w,h = spy_process_packet(c, width=w, height=h, pix=pa)
+            n = n+1
+    except ChaosError as m:
+        print(m, file=sys.stderr)
+    except KeyboardInterrupt:
+        pass
+    c.close()
+    print("Closed connection, waiting to let you see the window.")
+    try:
+        time.sleep(60)
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
UNC packets are unreliable, but sometimes useful. A demo is provided with a client for the SPY protocol for LISPM.

UNC packets can only work on the Packet interface, not the Stream.

The "foreign state" use of UNC packets mentioned in the Amber document is _not_ implemented.