### PR TITLE
Firewall functionality

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -61,6 +61,10 @@ Below, *%o* means an octal number, and square brackets [ ] are around optional p
 
 	Provide a list of private, non-routed subnets, where *list* is a list of comma-separated octal subnets, and *hostsfile* an optional hosts file defining hostname-address mapping for private subnets (including the standard private subnet 376).  The hosts file format is similar to a standard `/etc/hosts` file: lines beginning with `#` are ignored, other lines start with an octal address followed by whitespace and a list of whitespace-separated host names.
 
+- `firewall ` [ `enabled` no/yes ] [ `debug` off/on ] [ `log` off/on ] [ `rules` *filename* ]
+
+	Configures the firewall - see [FIREWALL](FIREWALL.md) for more info.
+
 ### LINKDEF:
 You can define links of two types: for whole subnets, and for individual hosts.
 

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -88,14 +88,20 @@ is parsed into something like
 || from subnet 7,11 allow |
 || to subnet 7 reject "Please don't disturb"
 
-so the contact name in an incoming packet need only be matched once against the ruleset. This also means that as soon as the address rules for a contact name run out, no more processing is needed since the contact name can't match another rule. That is, *unless* you also have a firewall rule for the `all` contact name token, which means processing will need to go on in case another rule matches. So if speed is important, try to avoid `all`. [Yes, there is a way to keep that equally efficient by injecting the address rule for `all` in all contact name address rules, but preserving the order seems a hassle.]
+so the contact name in an incoming packet need only be matched once against the ruleset. This also means that as soon as the address rules for a contact name run out without matches, no more processing is needed since the contact name can't match another rule. That is, *unless* you also have a firewall rule for the `all` contact name token, which means processing will need to go on in case another rule matches. So if speed is important, try to avoid `all`. [Yes, there is a way to keep that equally efficient by injecting the address rule for `all` in all contact name address rules, but preserving the order and handling explicit contacts appearing after `all` seems a bit of a hassle. Maybe one day.]
 
+(This also means the ruleset example above is equivalent and parsed to the same structure as the following reordering:)
+
+    "RTAPE" from subnet 7 allow
+	"EVAL" from subnet 7,11 allow
+	"RTAPE" to subnet 7 reject
+	"EVAL" to subnet 7 reject "Please don't disturb"
 
 ## Examples
 
 In `cbridge.conf`, specify
 
-`firewall enabled on debug off log on rules cbridge-rules.conf`
+`firewall enabled yes debug off log on rules cbridge-rules.conf`
 
 and then in `cbridge-rules.conf`, use
 

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -54,7 +54,7 @@ The *action* can be
 |`allow`| Allow the packet to be processed. This is the default.|
 |`drop`|Drop the packet without further processing.|
 |`reject` [*reason*]| Responds to the sender with a `CLS` packet with the optional *reason* (a double-quoted string) as data (default: "Connection rejected by firewall"). Note that there is no way of escaping " in the string. |
-|`forward` *dest* [*contact*]| Responds to the sender with a `FWD` packet, where *dest* is the octal address to refer to, and *contact* is the (optional) new contact name. (Default: the original contact name used.) **Note** that supplying a new contact name is not yet handled by cbridge (that's a bug). |
+|`forward` *dest* [*contact*]| Responds to the sender with a `FWD` packet, where *dest* is the octal address to refer to, and *contact* is the (optional) new contact name. (Default: the original contact name used.) |
 
 ### Note:
   - Explicit responses (`CLS` and `FWD`) are not sent for `BRD` attempts, since it would be pointless.

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -1,0 +1,58 @@
+# Firewall for Chaosnet
+
+A simple firewall is implemented, where you can define how to handle RFC and BRD packets.
+
+## Configuration
+
+`firewall ` [ `enabled` no/yes ] [ `debug` off/on ] [ `log` off/on ] [ `rules` *filename* ]
+
+| setting | description |
+| --- | --- |
+|`enabled`| used to enable/disable the firewall - default is `no` (disabled).|
+|`debug`| if on, writes about each packet processed and maybe more.|
+|`log` | if on, writes the verdict of packets handled (but not those not matched by some rule).|
+|`rules` | specifies a file containing the firewall rules (see below for description).|
+
+## Firewall rules
+
+The syntax for firewall rules is the following:
+
+<*contact*|`all`> [`from` *addrspec* (default `any`)] [`to` *addrspec* (default `myself`)] *action*
+
+| thing | description |
+| --- | --- |
+|*contact* | a contact name in doublequotes, e.g. `"FILE"` |
+|`all`| matches all contact names. |
+|*addrspec*| can be `any`, `host` *addrlist*, `subnet` *subnetlist*, or `myself`. The address/subnet lists are lists of octal numbers separated by commas but no space around the commas. `myself` matches any of the cbridge's own addresses (cf. `myaddr` in [the configuration documentation](CONFIGURATION.md).|
+
+The *action* can be
+| action | description |
+| --- | --- |
+|`allow`| Allow the packet to be processed. This is the default.|
+|`drop`|Drop the packet without further processing.|
+|`reject` [*reason*]| Responds to the sender with a `CLS` packet with the optional *reason* (a double-quoted string) as data (default: "Connection rejected by firewall").|
+|`forward` *dest* [*contact*]| Responds to the sender with a `FWD` packet, where *dest* | is the octal address to refer to, and *contact* is the (optional) new contact name. (Default: the original contact name used.)|
+
+### Note:
+  - Explicit responses (`CLS` and `FWD`) are not sent for `BRD` attempts, since it would be against the spec.
+  - Responses are sent using the destination addr and index as the source, so "on behalf of" the destination even though it might not be the cbridge itself.
+  - The rules are processed in the order given, until a match is found.
+
+## Examples
+
+In `cbridge.conf`, specify
+
+`firewall enabled on debug off log on rules cbridge-rules.conf`
+
+and then in `cbridge-rules.conf`, use
+
+	; Allow access to the remote tape servers from my local subnet
+	"RTAPE" from subnet 7 allow
+	; Reject all other connection attempts
+	"RTAPE" to subnet 7 reject
+	; Allow friendly ITSes to use MLDEV on my ITS
+	"MLDEV" from host 5460,3443,3150 to host 3405 allow
+	; Reject others
+	"MLDEV" to host 3405 reject "Who are you?"
+	; Subnet 47 is full of evil hackers - drop their connection attempts!
+	all from subnet 47 drop

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -46,7 +46,7 @@ where *contact* is a contact name in doublequotes, e.g. `"FILE"`, and `all` matc
 |`host` *addrlist* | matches those addresses in the list |
 |`subnet` *subnetlist* | matches addresses on those subnets in the list |
 |`myself`| matches any of the cbridge's own addresses (cf. `myaddr` in [the configuration documentation](CONFIGURATION.md). Use this rather than listing them explicitly in a `host` spec. |
-|`localnet` | matches any of the subnets of the cbridge's own addresses **EXCEPT** subnet 6, which is the "hub network" of the Global Chaosnet, thus never local. |
+|`localnet` | matches any of the subnets of the cbridge's own addresses (**EXCEPT** subnet 6, which is the "hub network" of the Global Chaosnet, thus never local). Use this for convenience to e.g. protect local services such as RTAPE without having to explicitly enumerate your local subnet(s). |
 |`broadcast`| matches the broadcast address (0). Only makes sense as a "to" address, and only applies to BRD packets.|
 
 The *action* can be
@@ -120,6 +120,8 @@ and then in `cbridge-rules.conf`, use
 	"MLDEV" to host 3405 reject "Who are you?"
 	; Subnet 47 is full of evil hackers - drop their connection attempts!
 	all from subnet 47 drop
+
+Notice the use of `localnet` in protecting RTAPE and EVAL.
 
 ## Discussion
 

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -46,6 +46,7 @@ where *contact* is a contact name in doublequotes, e.g. `"FILE"`, and `all` matc
 |`host` *addrlist* | matches those addresses in the list |
 |`subnet` *subnetlist* | matches addresses on those subnets in the list |
 |`myself`| matches any of the cbridge's own addresses (cf. `myaddr` in [the configuration documentation](CONFIGURATION.md). Use this rather than listing them explicitly in a `host` spec. |
+|`localnet` | matches any of the subnets of the cbridge's own addresses **EXCEPT** subnet 6, which is the "hub network" of the Global Chaosnet, thus never local. |
 |`broadcast`| matches the broadcast address (0). Only makes sense as a "to" address, and only applies to BRD packets.|
 
 The *action* can be
@@ -106,12 +107,13 @@ In `cbridge.conf`, specify
 and then in `cbridge-rules.conf`, use
 
 	; Allow access to the remote tape server from my local subnet
-	"RTAPE" from subnet 7 allow
+	"RTAPE" from localnet allow
 	; Reject all other connection attempts
-	"RTAPE" to subnet 7 reject
+	"RTAPE" to localnet reject
 	; For the EVAL servers on my LISPMs, allow local but also AMS and EJS subnets
-	"EVAL" from subnet 7,11,13 to any allow
-	"EVAL" to subnet 7 reject
+	"EVAL" from localnet to any allow
+	"EVAL" from subnet 11,13 to any allow
+	"EVAL" to localnet reject
 	; Allow friendly ITSes to use MLDEV on my ITS
 	"MLDEV" from host 5460,3443,3150 to host 3405 allow
 	; Reject others

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -1,21 +1,21 @@
 # Firewall for Chaosnet
 
-A simple firewall is implemented, where you can define how to handle RFC and BRD packets.
+A simple firewall is implemented in cbridge, where you can define how to handle connection requests (RFC and BRD packets).
 
-It can be used e.g. to restrict access to services running on your cbridge using [the NCP interface](NCP.md), or if your cbridge is in a "gateway position", to filter packets passing through it (i.e. not necessarily with the cbridge as destination).
+It can be used e.g. to restrict access to services running on your cbridge using [the NCP interface](NCP.md), or if your cbridge is in a "gateway position", to filter packets passing through it (i.e. not necessarily with the cbridge as final destination).
 
 ## Motivation
 
-The Chaosnet application protocols were mostly developed in a time when network users were all trustworthy, and since Chaosnet was a local area network it was easier to keep track of who had access. There was probably a bit of social control, hacker ethics etc, in play.
+The Chaosnet application protocols were mostly developed in a time when network users were all trustworthy, and since Chaosnet was a local area network it was easier to keep track of who had access. There was probably a bit of social control, [hacker ethics](https://en.wikipedia.org/wiki/Hacker_ethic) etc, in play.
 
-With the Global Chaosnet this doesn't necessarily hold anymore.
+With the [Global Chaosnet](https://chaosnet.net) this doesn't necessarily hold anymore, but retrofitting access control in many ancient programs would be a daunting task.
 
 ## Use cases
 
 The firewall could be useful e.g. if
-  - you run local `FILE` or `RTAPE` servers but don't want to give the whole Chaosnet access to them
+  - you run local `FILE` or `RTAPE` servers but don't want to give the whole Chaosnet read&write access to their contents
   - you run Lisp Machines on your network, which e.g may have servers for `EVAL`, `BAND-TRANSFER`, `REMOTE-DISK` etc which you want to protect
-  - you run a `TCP` (gateway server)[https://github.com/Chaosnet/chaosnet-tools] but want to avoid opening up the Chaosnet to Evil Internet Hackers
+  - you run a `TCP` [gateway server](https://github.com/Chaosnet/chaosnet-tools) but want to avoid opening up the Chaosnet to *Evil Automated Internet Hackers*
   - you at the same time have servers for less sensitive protocols such as `NAME`, `SUPDUP`, `TELNET`, `TIME`, `UPTIME` etc, which you want to keep open and public
 
 (See the [Computer History Wiki](https://gunkies.org/wiki/List_of_Chaos_application_protocols) or the [Chaosnet wiki](https://chaosnet.net/protocol#application_layer) for descriptions of the application protocols.)
@@ -79,6 +79,8 @@ To optimize processing a little, rules are collected by contact name, so
 	
 is parsed into something like
 
+| contact | address rules |
+| --- | --- |
 | "RTAPE" | |
 || from subnet 7 allow |
 || to subnet 7 reject |

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -38,7 +38,7 @@ The *action* can be
 |`allow`| Allow the packet to be processed. This is the default.|
 |`drop`|Drop the packet without further processing.|
 |`reject` [*reason*]| Responds to the sender with a `CLS` packet with the optional *reason* (a double-quoted string) as data (default: "Connection rejected by firewall").|
-|`forward` *dest* [*contact*]| Responds to the sender with a `FWD` packet, where *dest* | is the octal address to refer to, and *contact* is the (optional) new contact name. (Default: the original contact name used.) **Note** that supplying a new contact name is not yet handled by cbridge (that's a bug). |
+|`forward` *dest* [*contact*]| Responds to the sender with a `FWD` packet, where *dest* is the octal address to refer to, and *contact* is the (optional) new contact name. (Default: the original contact name used.) **Note** that supplying a new contact name is not yet handled by cbridge (that's a bug). |
 
 ### Note:
   - Explicit responses (`CLS` and `FWD`) are not sent for `BRD` attempts, since it would be against the spec.

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -4,6 +4,22 @@ A simple firewall is implemented, where you can define how to handle RFC and BRD
 
 It can be used e.g. to restrict access to services running on your cbridge using [the NCP interface](NCP.md), or if your cbridge is in a "gateway position", to filter packets passing through it (i.e. not necessarily with the cbridge as destination).
 
+## Motivation
+
+The Chaosnet application protocols were mostly developed in a time when network users were all trustworthy, and since Chaosnet was a local area network it was easier to keep track of who had access. There was probably a bit of social control, hacker ethics etc, in play.
+
+With the Global Chaosnet this doesn't necessarily hold anymore.
+
+## Use cases
+
+The firewall could be useful e.g. if
+  - you run local `FILE` or `RTAPE` servers but don't want to give the whole Chaosnet access to them
+  - you run Lisp Machines on your network, which e.g may have servers for `EVAL`, `BAND-TRANSFER`, `REMOTE-DISK` etc which you want to protect
+  - you run a `TCP` (gateway server)[https://github.com/Chaosnet/chaosnet-tools] but want to avoid opening up the Chaosnet to Evil Internet Hackers
+  - you at the same time have servers for less sensitive protocols such as `NAME`, `SUPDUP`, `TELNET`, `TIME`, `UPTIME` etc, which you want to keep open and public
+
+(See the [Computer History Wiki](https://gunkies.org/wiki/List_of_Chaos_application_protocols) or the [Chaosnet wiki](https://chaosnet.net/protocol#application_layer) for descriptions of the application protocols.)
+
 ## Configuration
 
 `firewall ` [ `enabled` no/yes ] [ `debug` off/on ] [ `log` off/on ] [ `rules` *filename* ]
@@ -43,11 +59,34 @@ The *action* can be
 ### Note:
   - Explicit responses (`CLS` and `FWD`) are not sent for `BRD` attempts, since it would be pointless.
   - Responses are sent using the destination addr and index as the source, so "on behalf of" the destination even though it might not be the cbridge itself.
-  - The rules are processed in the order given, until a match is found. (*Explain efficiency*)
+  - The rules are processed in the order given, until a match is found.
 
-Broadcast (BRD) packets are delivered to all hosts (on the subnets in the BRD mask, see [MIT AIM 628 Section 4.5](https://chaosnet.net/amber.html#Broadcast)), and could therefore be considered to match (basically) all `to` specifications in firewall rules. This would, however, make it difficult to be precise in filtering them: the `to` specification wouldn't matter. So in the general case of forwarding packets, BRD packets only match rules with `to broadcast` and `to any` specifications, exceptwhile for packets to `myself`, BRD packets are considered to match `myself` specifications. (Similar handling should be done in other "endpoint delivery" cases.)
+#### Broadcast matching
+
+Broadcast (BRD) packets are delivered to all hosts (on the subnets in the BRD mask, see [MIT AIM 628 Section 4.5](https://chaosnet.net/amber.html#Broadcast)), and could therefore be considered to match (basically) all `to` specifications in firewall rules. This would, however, make it difficult to be precise in filtering them: the `to` specification wouldn't matter. So in the general case of cbridge forwarding packets, BRD packets only match rules with `to broadcast` and `to any` specifications, except for packets which are delivered to cbridge itself. For those,  BRD packets are considered to match `myself` specifications.
+
+On the other hand, most of the protocols which are useful with BRD are so-called "simple" protocols, which are mostly harmless.
 
 **Give an example, perhaps a table, to make this more understandable?**
+
+#### Optimization
+To optimize processing a little, rules are collected by contact name, so 
+
+    "RTAPE" from subnet 7 allow
+	"RTAPE" to subnet 7 reject
+	"EVAL" from subnet 7,11 allow
+	"EVAL" to subnet 7 reject "Please don't disturb"
+	
+is parsed into something like
+
+| "RTAPE" | |
+|| from subnet 7 allow |
+|| to subnet 7 reject |
+| "EVAL" ||
+|| from subnet 7,11 allow |
+|| to subnet 7 reject "Please don't disturb"
+
+so the contact name in an incoming packet need only be matched once against the ruleset. This also means that as soon as the address rules for a contact name run out, no more processing is needed since the contact name can't match another rule. That is, *unless* you also have a firewall rule for the `all` contact name token, which means processing will need to go on in case another rule matches. So if speed is important, try to avoid `all`. [Yes, there is a way to keep that equally efficient by injecting the address rule for `all` in all contact name address rules, but preserving the order seems a hassle.]
 
 
 ## Examples
@@ -62,6 +101,9 @@ and then in `cbridge-rules.conf`, use
 	"RTAPE" from subnet 7 allow
 	; Reject all other connection attempts
 	"RTAPE" to subnet 7 reject
+	; For the EVAL servers on my LISPMs, allow local but also AMS and EJS subnets
+	"EVAL" from subnet 7,11,13 allow
+	"EVAL" to subnet 7 reject
 	; Allow friendly ITSes to use MLDEV on my ITS
 	"MLDEV" from host 5460,3443,3150 to host 3405 allow
 	; Reject others

--- a/FIREWALL.md
+++ b/FIREWALL.md
@@ -21,15 +21,15 @@ The syntax for firewall rules is the following:
 
 <*contact*|`all`> [`from` *addrspec* (default `any`)] [`to` *addrspec* (default `myself`)] *action*
 
-| thing | description |
+where *contact* is a contact name in doublequotes, e.g. `"FILE"`, and `all` matches all contact names.
+*addrspec* can be any of the below, where the address/subnet lists are lists of octal numbers separated by commas (but no space around the commas).
+
+| *addrspec* | description |
 | --- | --- |
-|*contact* | a contact name in doublequotes, e.g. `"FILE"` |
-|`all`| matches all contact names. |
-|*addrspec*| can be any of the below, where the address/subnet lists are lists of octal numbers separated by commas but no space around the commas. |
 |`any` | matches any address (including broadcast)  |
 |`host` *addrlist* | matches those addresses in the list |
 |`subnet` *subnetlist* | matches addresses on those subnets in the list |
-|`myself`| matches any of the cbridge's own addresses (cf. `myaddr` in [the configuration documentation](CONFIGURATION.md).|
+|`myself`| matches any of the cbridge's own addresses (cf. `myaddr` in [the configuration documentation](CONFIGURATION.md). Use this rather than listing them explicitly in a `host` spec. |
 |`broadcast`| matches the broadcast address (0). Only makes sense as a "to" address, and only applies to BRD packets.|
 
 The *action* can be
@@ -41,10 +41,14 @@ The *action* can be
 |`forward` *dest* [*contact*]| Responds to the sender with a `FWD` packet, where *dest* is the octal address to refer to, and *contact* is the (optional) new contact name. (Default: the original contact name used.) **Note** that supplying a new contact name is not yet handled by cbridge (that's a bug). |
 
 ### Note:
-  - Explicit responses (`CLS` and `FWD`) are not sent for `BRD` attempts, since it would be against the spec.
+  - Explicit responses (`CLS` and `FWD`) are not sent for `BRD` attempts, since it would be pointless.
   - Responses are sent using the destination addr and index as the source, so "on behalf of" the destination even though it might not be the cbridge itself.
   - The rules are processed in the order given, until a match is found. (*Explain efficiency*)
-  - Specifying `broadcast` might block/match much more than you wanted, depending on the placement of your cbridge.
+
+Broadcast (BRD) packets are delivered to all hosts (on the subnets in the BRD mask, see [MIT AIM 628 Section 4.5](https://chaosnet.net/amber.html#Broadcast)), and could therefore be considered to match (basically) all `to` specifications in firewall rules. This would, however, make it difficult to be precise in filtering them: the `to` specification wouldn't matter. So in the general case of forwarding packets, BRD packets only match rules with `to broadcast` and `to any` specifications, exceptwhile for packets to `myself`, BRD packets are considered to match `myself` specifications. (Similar handling should be done in other "endpoint delivery" cases.)
+
+**Give an example, perhaps a table, to make this more understandable?**
+
 
 ## Examples
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CFLAGS+=-Wall
 
 all: cbridge hostat finger
 
-OBJS = cbridge.o contacts.o usockets.o chtls.o chudp.o debug.o chether.o dns.o chip.o ncp.o pkqueue.o
+OBJS = cbridge.o contacts.o usockets.o chtls.o chudp.o debug.o chether.o dns.o chip.o ncp.o pkqueue.o firewall.o
 
 # YMMV, but sometimes openssl etc are in /opt/local.
 # -lssl and -lcrypto are needed only for TLS.
@@ -68,6 +68,9 @@ ncp.o: ncp.c ncp.h cbridge.h pkqueue.h
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 pkqueue.o: pkqueue.c pkqueue.h cbridge-chaos.h
+	$(CC) -c $(CFLAGS) -o $@ $<
+
+firewall.o: firewall.c cbridge.h cbridge-chaos.h
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 hostat: hostat.c cbridge-chaos.h

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It also implements the transport layer of Chaosnet (using any of the above link 
 - [EXAMPLES](EXAMPLES.md) for some example configurations.
 - [TLS](TLS.md) for how to get a certificate for Chaosnet-over-TLS.
 - [NCP](NCP.md) for how to connect a user program to Chaosnet.
+- [FIREWALL](FIREWALL.md) for how to configure the built-in firewall. 
 - [HISTORY](HISTORY.md) for some historic notes.
 - [COPYRIGHT](COPYRIGHT.md) for copyright notice and acknowledgements.
 

--- a/cbridge.c
+++ b/cbridge.c
@@ -1024,7 +1024,8 @@ forward_chaos_pkt(struct chroute *src, u_char cost, u_char *data, int dlen, u_ch
   // Allow firewall to do its job
   if ((ch_opcode(ch) == CHOP_RFC) || (ch_opcode(ch) == CHOP_BRD)) {
     if (firewall_handle_forward(ch) < 0) {
-      if (debug || verbose) fprintf(stderr,"Firewall says to drop packet from %#o to %#o.\n",
+      if (debug || verbose) fprintf(stderr,"Firewall says to drop %s packet from %#o to %#o.\n",
+				    ch_opcode_name(ch_opcode(ch)),
 				    ch_srcaddr(ch), ch_destaddr(ch));
       return;			// Firewall says "no"
     }
@@ -1038,7 +1039,8 @@ forward_chaos_pkt(struct chroute *src, u_char cost, u_char *data, int dlen, u_ch
 	      dchad);
     // Let firewall have a more precise say for BRD pkts to me
     if ((ch_opcode(ch) == CHOP_BRD) && (firewall_handle_pkt_for_me(ch) < 0)) {
-      if (debug || verbose) fprintf(stderr,"Firewall says to drop packet from %#o to me (%#o).\n",
+      if (debug || verbose) fprintf(stderr,"Firewall says to drop %s packet from %#o to me (%#o).\n",
+				    ch_opcode_name(ch_opcode(ch)),
 				    ch_srcaddr(ch), ch_destaddr(ch));
       // don't drop it, the broadcast case below needs it
     } else

--- a/cbridge.c
+++ b/cbridge.c
@@ -1024,8 +1024,8 @@ forward_chaos_pkt(struct chroute *src, u_char cost, u_char *data, int dlen, u_ch
   // Allow firewall to do its job
   if ((ch_opcode(ch) == CHOP_RFC) || (ch_opcode(ch) == CHOP_BRD)) {
     if (firewall_handle_forward(ch) < 0) {
-      if (debug) fprintf(stderr,"Firewall says to drop packet from %#o to %#o.\n",
-			 ch_srcaddr(ch), ch_destaddr(ch));
+      if (debug || verbose) fprintf(stderr,"Firewall says to drop packet from %#o to %#o.\n",
+				    ch_srcaddr(ch), ch_destaddr(ch));
       return;			// Firewall says "no"
     }
   }
@@ -1038,8 +1038,8 @@ forward_chaos_pkt(struct chroute *src, u_char cost, u_char *data, int dlen, u_ch
 	      dchad);
     // Let firewall have a more precise say for BRD pkts to me
     if ((ch_opcode(ch) == CHOP_BRD) && (firewall_handle_pkt_for_me(ch) < 0)) {
-      if (debug) fprintf(stderr,"Firewall says to drop packet from %#o to me (%#o).\n",
-			 ch_srcaddr(ch), ch_destaddr(ch));
+      if (debug || verbose) fprintf(stderr,"Firewall says to drop packet from %#o to me (%#o).\n",
+				    ch_srcaddr(ch), ch_destaddr(ch));
       // don't drop it, the broadcast case below needs it
     } else
       // OK, take care of it

--- a/cbridge.c
+++ b/cbridge.c
@@ -178,6 +178,7 @@ void print_private_hosts_config(void);
 // Firewall
 int parse_firewall_config_line(void);
 int firewall_handle_rfc_or_brd(struct chaos_header *pkt);
+void print_firewall_rules(void);
 
 time_t boottime;
 
@@ -2067,6 +2068,7 @@ print_stats(int sig)
   print_host_stats();
 
   print_ncp_stats();
+  print_firewall_rules();	// to get #matches
 }
 
 void

--- a/firewall.c
+++ b/firewall.c
@@ -1,0 +1,617 @@
+/* Copyright © 2024 Björn Victor (bjorn@victor.se) */
+/*  Simple firewall for cbridge, the bridge program for various Chaosnet implementations. */
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "cbridge.h"
+
+static int firewall_enabled = 0;
+static int debug_firewall = 0;
+static int log_firewall = 0;
+
+void print_firewall_rules(void);
+
+typedef enum rule_addr_type {	// A rule address can have this type:
+  rule_addr_any=1, 		// "any" matching any addr
+  rule_addr_host,		// a specific host addr
+  rule_addr_subnet,		// a specific subnet
+  rule_addr_myself,		// "myself" meaning any of the addresses of this cbridge
+} rule_addr_t;
+struct rule_addr {		// A rule address has
+  rule_addr_t type;		// a type (above)
+  u_int n_addrs;
+  u_short *addrs; // and an array of addresses (except for "any" and "myself")
+};
+typedef enum rule_action_type {	// What to do when the rule matched
+  rule_action_allow=1,		// Just allow it
+  rule_action_drop,		// Just drop it
+  rule_action_reject,		// Send a CLS in response
+  rule_action_forward,		// Send a FWD in response
+} rule_action_t;
+struct rule_action {
+  rule_action_t action;		// What to do
+  union {
+    char *reject_reason;	// the CLS reason to use
+    struct forward_args {	// the FWD args to use
+      u_short forward_addr;
+      char *forward_contact;	// (default "same as in RFC")
+    } *fwd_args;
+  } args;
+};
+struct contact_rule {
+  struct rule_addr *rule_sources; // the sources t match
+  struct rule_addr *rule_dests;	  // the dests to match
+  struct rule_action *rule_action; // what happens
+  u_int rule_match_count;	  // how many times it matched (for statistics)
+};
+typedef enum rule_contact_type {
+  rule_contact_all=1,
+  rule_contact_string,
+} rule_contact_t;
+struct firewall_rule {
+  rule_contact_t contact_type;	// the type of contact (all or string)
+  char *contact;		// the contact name (for rule_contact_string)
+  u_int contact_length;		// the strlen 
+  u_int n_rules;		// how long the array is
+  struct contact_rule **rules;	// the array of rules
+};
+
+static u_int n_firewall_rules = 0;
+static struct firewall_rule **fw_rules = NULL;
+
+static int 
+num_occurrences(char c, char *s)
+{
+  int i = 0;
+  while ((s = index(s,c)) != NULL) {
+    i++; s++;
+  }
+  return i;
+}
+
+static struct rule_addr *
+parse_numeric_addrs(char *tok, struct rule_addr *ruleaddr) 
+{
+  int n = num_occurrences(',', tok)+1;
+  u_short *addrs = calloc(n, sizeof(u_short));
+  for (int i = 0; i < n; i++) {
+    char *comma = index(tok,',');
+    if (comma != NULL) *comma = '\0';
+    if ((sscanf(tok,"%ho",&addrs[i]) != 1) || 
+	(ruleaddr->type == rule_addr_subnet && (addrs[i] > 0xff || addrs[i] == 0)) ||
+	(ruleaddr->type == rule_addr_host && !valid_chaos_host_address(addrs[i]))) {
+      fprintf(stderr,"Firewall: bad %s spec '%s'\n", ruleaddr->type == rule_addr_host ? "host" : "subnet", tok);
+      return NULL;
+    }
+    if (comma != NULL) tok = comma+1;
+  }
+  ruleaddr->n_addrs = n;
+  ruleaddr->addrs = addrs;
+  return ruleaddr;
+}
+static struct rule_addr *
+make_addr_spec(rule_addr_t type)
+{
+  struct rule_addr *r = malloc(sizeof(struct rule_addr));
+  if (r == NULL) abort();
+  r->type = type;
+  return r;
+}
+static struct rule_addr *
+parse_addr_spec()
+{
+  char *tok = strtok(NULL," \t\r\n");
+  rule_addr_t type;
+  struct rule_addr *rule;
+  if (tok != NULL) {
+    if (strcasecmp(tok,"subnet") == 0 || strcasecmp(tok,"net") == 0) 
+      type = rule_addr_subnet;
+    else if (strcasecmp(tok,"host") == 0) 
+      type = rule_addr_host;
+    else if (strcasecmp(tok,"any") == 0)
+      type = rule_addr_any;
+    else if (strcasecmp(tok,"myself") == 0)
+      type = rule_addr_myself;
+    else {
+      fprintf(stderr,"Firewall: bad address keyword '%s', expected subnet/host/any/myself\n", tok);
+      return NULL;
+    }
+    rule = malloc(sizeof(struct rule_addr));
+    if (rule == NULL) abort();
+    rule->type = type;
+    rule->n_addrs = 0;
+    rule->addrs = NULL;
+    if (type == rule_addr_subnet || type == rule_addr_host) {
+      tok = strtok(NULL," \t\r\n");
+      if (tok != NULL) {
+	rule = parse_numeric_addrs(tok, rule);
+	if (rule == NULL || rule->n_addrs == 0) {
+	  return NULL;
+	}
+      }
+    }
+    return rule;
+  } else 
+    return NULL;
+}
+static char *
+parse_quoted_string(char *tok) 
+{
+  if (tok[0] != '"' || strlen(tok) < 2)
+    return NULL;		// Not a quoted string
+  int slen = strlen(tok);
+  char *sval = calloc(1,256);	// Get a string
+  ++tok;				// Skip over "
+  --slen;				// update len
+
+  // Consume more tokens, separating them with space
+  while (tok != NULL && tok[slen-1] != '"') {
+    strcat(sval, tok);
+    strcat(sval, " ");
+    tok = strtok(NULL," \t\r\n");
+    slen = strlen(tok);
+  }
+  if (tok != NULL && tok[slen-1] == '"') {
+    tok[slen-1] = '\0';		// Zap final "
+    strcat(sval, tok);
+    return sval;
+  } else {
+    return NULL;
+  }
+}
+struct forward_args *
+parse_forward_args()
+{
+  u_short fwd;
+  char *new_contact;
+  char *tok = strtok(NULL," \t\r\n");
+  if (tok != NULL) {
+    if (sscanf(tok,"%ho",&fwd) != 1 || !valid_chaos_host_address(fwd)) {
+      fprintf(stderr,"Firewall: bad forward address %s\n", tok);
+      return NULL;
+    }
+    tok = strtok(NULL," \t\r\n");
+    if (tok != NULL)
+      new_contact = parse_quoted_string(tok);
+    struct forward_args *fa = malloc(sizeof(struct forward_args));
+    if (fa == NULL) abort();
+    fa->forward_addr = fwd;
+    fa->forward_contact = new_contact;
+    return fa;
+  } else {
+    fprintf(stderr,"Firewall: forward args missing\n");
+    return NULL;
+  }
+}
+// <"contact"|all> [from <source> (default any)] [to <dest> (default any)] allow/drop/forward <destaddr [contact]>/reject [reason]
+// source,dest: net sn-list | host addr-list | any | myself (meaning "any of this cbridge's addresses")
+// action: allow | drop | forward dest [new-contact] | reject Reason (default "No server for this contact name")
+static int
+parse_firewall_line(char *line)
+{
+  rule_contact_t contact_type;
+  char *contact_name = NULL;
+
+  // construct the rule action
+  struct rule_action *rule_action = calloc(1,sizeof(struct rule_action));
+  // construct the contact rule
+  struct contact_rule *rule = calloc(1,sizeof(struct contact_rule));
+
+  char *tok = NULL;
+  // Look for comment start
+  char *comment_start = index(line, '#');
+  if (comment_start == NULL) comment_start = index(line, ';');
+  if (comment_start != NULL)
+    *comment_start = '\0';	// Zap string at that point
+  tok = strtok(line," \t\r\n");
+  if (tok == NULL)
+    return 0;			// Empty line
+
+  // First is contact name in doublequotes, or all
+  if (strcasecmp(tok, "all") == 0)
+    contact_type = rule_contact_all;
+  else {
+    contact_type = rule_contact_string;
+    contact_name = parse_quoted_string(tok);
+    if (contact_name == NULL) {
+      fprintf(stderr,"firewall config parse error: not a quoted string: %s\n", tok);
+      return -1;
+    }
+  }
+  // next is a keyword: from/to/[action]
+  while (tok != NULL) {
+    tok = strtok(NULL, " \t\r\n");
+    if (tok != NULL) {
+      if (strcasecmp(tok,"from") == 0) {
+	// parse an addr spec
+	rule->rule_sources = parse_addr_spec();
+	if (rule->rule_sources == NULL)
+	  return -1;
+      } else if (strcasecmp(tok,"to") == 0) {
+	rule->rule_dests = parse_addr_spec();
+	if (rule->rule_dests == NULL)
+	  return -1;
+      } else if (strcasecmp(tok, "allow") == 0) {
+	rule_action->action = rule_action_allow;
+      } else if (strcasecmp(tok, "drop") == 0) {
+	rule_action->action = rule_action_drop;
+      } else if (strcasecmp(tok,"forward") == 0) {
+	rule_action->action = rule_action_forward;
+	// parse parameters
+	rule_action->args.fwd_args = parse_forward_args();
+	if (rule_action->args.fwd_args == NULL)
+	  return -1;
+      } else if (strcasecmp(tok,"reject") == 0) {
+	rule_action->action = rule_action_reject;
+	// parse quoted string
+	tok = strtok(NULL," \t\r\n");
+	if (tok != NULL)
+	  rule_action->args.reject_reason = parse_quoted_string(tok);
+	if (rule_action->args.reject_reason == NULL)
+	  rule_action->args.reject_reason = "Connection rejected by firewall"; // "No server for this contact name";
+      } else {
+	fprintf(stderr,"Firewall: bad keyword '%s'\n", tok);
+	return -1;
+      }
+    }
+  }
+  rule->rule_action = rule_action;
+  if (rule->rule_action == NULL) {
+    fprintf(stderr,"Firewall: no action specified for rule.\n");
+    return -1;
+  }
+  // Default these
+  if (rule->rule_sources == NULL) {
+    rule->rule_sources = make_addr_spec(rule_addr_any); // Default "from" is any
+  }
+  if (rule->rule_dests == NULL) {
+    rule->rule_dests = make_addr_spec(rule_addr_myself); // Default "to" is myself, not any
+  }
+
+  // Remind people.
+  if (contact_type == rule_contact_string && strcasecmp(contact_name, "STATUS") == 0 &&
+      rule_action->action != rule_action_allow) 
+    fprintf(stderr,"%%%% Warning: disallowing STATUS is against the spec.\n");
+
+
+  // Find the contact name in fw_rules, add the rule to it
+  if (fw_rules == NULL) {
+    fw_rules = malloc(sizeof(struct firewall_rule));
+  }
+  struct firewall_rule *this = NULL;
+  for (int i = 0; i < n_firewall_rules; i++) {
+    if ((fw_rules[i]->contact_type == contact_type) && 
+	(contact_type == rule_contact_all || (strcasecmp(fw_rules[i]->contact, contact_name) == 0))) {
+      this = fw_rules[i];
+      break;
+    }
+  }
+  if (this == NULL) {		// Didn't find it, add space for it
+    fw_rules = realloc(fw_rules, (n_firewall_rules+1)*sizeof(struct firewall_rule));
+    fw_rules[n_firewall_rules] = calloc(1, sizeof(struct firewall_rule));
+    this = fw_rules[n_firewall_rules++];
+  }
+  this->contact_type = contact_type;
+  if (contact_type == rule_contact_string) { 
+    this->contact = contact_name;
+    this->contact_length = strlen(contact_name);
+  }
+  // add the rule to this->rules
+  if (this->rules == NULL) {	// no rules yet, add the first
+    this->rules = malloc(sizeof(struct contact_rule));
+    this->n_rules = 0;
+  }
+  else
+    this->rules = realloc(this->rules, (this->n_rules+1)*sizeof(struct contact_rule));
+  this->rules[this->n_rules++] = rule;
+  return 0;
+}
+
+// Returns success (0) or failure (-1, for syntax error or other fatal error)
+// Creates the config in fw_rules.
+// Warn if both source and addr are any when action is not allow?
+static int 
+parse_firewall_file(char *fname)
+{
+  FILE *fp = fopen(fname,"r");
+  if (fp == NULL) {
+    fprintf(stderr,"Can't open firewall config file \"%s\"\n", fname);
+    return -1;
+  }
+  char *line = NULL;
+  size_t linecap = 0;
+  ssize_t linelen;
+  while (!feof(fp)) {
+    linelen = getline(&line, &linecap, fp);
+    if (linelen < 0) {
+      if (feof(fp)) {
+	fclose(fp);
+	return 0;
+      }  
+      fclose(fp);
+      fprintf(stderr,"While reading from \"%s\": %s\n", fname, strerror(errno));
+      return -1;
+    }
+    if (parse_firewall_line(line) < 0) {
+      fclose(fp);
+      return -1;
+    }
+  }
+  fclose(fp);
+  return 0;
+}
+
+static int parse_on_off(char *name)
+{
+  char *tok = strtok(NULL, " \t\r\n");
+  if (tok == NULL) {
+    fprintf(stderr,"firewall: no arg specified for '%s'\n", name);
+    return -1;
+  } else if ((strcasecmp(tok,"on") == 0) || (strcasecmp(tok,"yes") == 0)) {
+    return 1;
+  } else if ((strcasecmp(tok,"off") == 0) || (strcasecmp(tok,"no") == 0)) {
+    return 0;
+  } else {
+    fprintf(stderr,"firewall: bad '%s' arg %s specified\n", name, tok);
+    return -1;
+  }
+}
+
+// Called from cbridge.c for the cbridge.conf line:
+// firewall enabled yes/no debug yes/no log yes/no rules fname
+int parse_firewall_config_line()
+{
+  char *tok = NULL;
+  while ((tok = strtok(NULL, " \t\r\n")) != NULL) {
+    if (strcasecmp(tok,"enabled") == 0) {
+      firewall_enabled = parse_on_off("enabled");
+      if (firewall_enabled < 0) 
+	return -1;
+    } else if (strcasecmp(tok,"debug") == 0) {
+      debug_firewall = parse_on_off("debug");
+      if (debug_firewall < 0)
+	return -1;
+    } else if (strcasecmp(tok,"log") == 0) {
+      log_firewall = parse_on_off("log");
+      if (log_firewall < 0)
+	return -1;
+    } else if (strcasecmp(tok,"rules") == 0) {
+      tok = strtok(NULL," \t\r\n");
+      if (tok == NULL) {
+	fprintf(stderr,"firewall: no arg specified for 'rules'\n");
+	return -1;
+      }
+      if (parse_firewall_file(tok) < 0)
+	return -1;
+    } else {
+      fprintf(stderr,"bad firewall keyword %s\n", tok);
+      return -1;
+    }
+  }
+  if (debug_firewall) {
+    printf("firewall %s: debug %s log %s\n", firewall_enabled ? "enabled" : "disabled",
+	   debug_firewall ? "on" : "off", log_firewall ? "on" : "off");
+    print_firewall_rules();
+  }
+  // @@@@ validate config
+  if (n_firewall_rules == 0 && firewall_enabled == 1) {
+    printf("%%%% Warning: firewall was enabled, but no rules given. Disabling.\n");
+    firewall_enabled = 0;
+  } else if (n_firewall_rules > 0 && firewall_enabled == 0)
+    printf("%%%% Warning: firewall disabled, but rules given. I hope you wanted this.\n");
+  return 0;
+}
+
+static void
+print_firewall_action(struct rule_action *a)
+{
+  switch (a->action) {
+  case rule_action_allow: printf("allow"); return;
+  case rule_action_drop: printf("drop"); return;
+  case rule_action_reject: printf("reject \"%s\"", a->args.reject_reason); return;
+  case rule_action_forward: 
+    printf("forward %o \"%s\"", a->args.fwd_args->forward_addr, a->args.fwd_args->forward_contact);
+  }
+}
+static void 
+print_firewall_addrs(struct rule_addr *addr)
+{
+  switch (addr->type) {
+  case rule_addr_any: printf("any"); return;
+  case rule_addr_myself: printf("myself"); return;
+  case rule_addr_host: printf("host "); break;
+  case rule_addr_subnet: printf("subnet "); break;
+  }
+  if (addr->n_addrs > 0) {
+    for (int i = 0; i < addr->n_addrs-1; i++) 
+      printf("%o,", addr->addrs[i]);
+    printf("%o", addr->addrs[addr->n_addrs-1]);
+  }
+}
+void print_firewall_rules(void)
+{
+  printf("Firewall has rues for %d contacts:\n", n_firewall_rules);
+  for (int c = 0; c < n_firewall_rules; c++) {
+    if (fw_rules[c]->contact_type == rule_contact_string)
+      printf("%2d: \"%s\"\n", c, fw_rules[c]->contact);
+    else
+      printf("%2d: *\n", c);
+    for (int r = 0; r < fw_rules[c]->n_rules; r++) {
+      printf("   %2d: from ", r); print_firewall_addrs(fw_rules[c]->rules[r]->rule_sources);
+      printf(" to "); print_firewall_addrs(fw_rules[c]->rules[r]->rule_dests);
+      printf(" "); print_firewall_action(fw_rules[c]->rules[r]->rule_action);
+      printf(" [matched %d times]\n", fw_rules[c]->rules[r]->rule_match_count);
+    }
+  }
+}
+
+// Match a rule address with an actual address.
+static int 
+addr_match(struct rule_addr *addr, u_short pkaddr) 
+{
+  if (addr->type == rule_addr_any) return 1;
+  if (addr->type == rule_addr_host) {
+    for (int i = 0; i < addr->n_addrs; i++)
+      if (addr->addrs[i] == pkaddr)
+	return 1;
+  } else if (addr->type == rule_addr_subnet) {
+    for (int i = 0; i < addr->n_addrs; i++)
+      if (addr->addrs[i] == (pkaddr >> 8))
+	return 1;
+  } else if (addr->type == rule_addr_myself)
+    return is_mychaddr(pkaddr);
+  return 0;
+}
+
+// (There are too many functions like this one, e.g. in ncp.c)
+static void
+send_basic_response(struct chaos_header *pkt, int opcode, char *data, int len, u_short fwd_addr)
+{
+  u_char resp[CH_PK_MAXLEN];
+  struct chaos_header *ch = (struct chaos_header *)resp;
+
+  // Initialize header
+  memset(resp, 0, CHAOS_HEADERSIZE);
+  set_ch_opcode(ch, opcode);
+  // Use src/dest from pkt we're responding to (even if dest wasn't us!)
+  set_ch_destaddr(ch, ch_srcaddr(pkt));
+  set_ch_destindex(ch, ch_srcindex(pkt));
+  set_ch_srcaddr(ch, ch_destaddr(pkt));
+  set_ch_srcindex(ch, ch_destindex(pkt));
+  set_ch_nbytes(ch, len);
+  // Set up content
+  u_short *datao = (u_short *)&resp[CHAOS_HEADERSIZE];
+  if ((opcode == CHOP_CLS) || (opcode == CHOP_FWD)) {
+    if (opcode == CHOP_FWD)
+      set_ch_ackno(ch, fwd_addr);
+    strncpy((char *)&resp[CHAOS_HEADERSIZE], data, len); // Copy data (CLS reason or FWD contact)
+    htons_buf(datao, datao, len);
+    // Send it off
+    send_chaos_pkt(resp, len+CHAOS_HEADERSIZE);
+  } else {
+    fprintf(stderr,"%%%% Firewall %s: opcode %#o (%s) not handled\n", __func__, opcode, ch_opcode_name(opcode));
+  }
+}
+// send CLS using the pkt dest as source
+static void
+send_cls_response(struct chaos_header *pkt, char *reason)
+{
+  send_basic_response(pkt, CHOP_CLS, reason, strlen(reason), 0);
+}
+// send FWD using the pkt dest as source
+static void
+send_fwd_response(struct chaos_header *pkt, u_short newdest, char *newcontact)
+{
+  send_basic_response(pkt, CHOP_FWD, newcontact, strlen(newcontact), newdest);
+}
+
+static int 
+do_action(struct contact_rule *rule, struct chaos_header *pkt)
+{
+  u_char contact[CH_PK_MAXLEN];
+  get_packet_string(pkt, contact, sizeof(contact));
+
+  switch (rule->rule_action->action) {
+  case rule_action_allow:
+    if (log_firewall)
+      printf("allow %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	     ch_destaddr(pkt), ch_destindex(pkt));
+    return 0;
+  case rule_action_drop:
+    if (log_firewall)
+      printf("drop %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	     ch_destaddr(pkt), ch_destindex(pkt));
+    return -1;
+  case rule_action_reject:
+    if (log_firewall)
+      printf("reject %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	     ch_destaddr(pkt), ch_destindex(pkt));
+    // send CLS using the pkt dest as source (but not for BRD)
+    if (ch_opcode(pkt) != CHOP_BRD)
+      send_cls_response(pkt, rule->rule_action->args.reject_reason);
+    return -1;
+  case rule_action_forward:
+    if (log_firewall)
+      printf("forward %s \"%s\" from <%#o,%#x> to <%#o,%#x>: %#o \"%s\"\n",
+	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	     ch_destaddr(pkt), ch_destindex(pkt), 
+	     rule->rule_action->args.fwd_args->forward_addr, rule->rule_action->args.fwd_args->forward_contact);
+    // send FWD using the pkt dest as source (but not for BRD)
+    if (ch_opcode(pkt) != CHOP_BRD)
+      send_fwd_response(pkt, rule->rule_action->args.fwd_args->forward_addr, rule->rule_action->args.fwd_args->forward_contact);
+    return -1;
+  }
+}
+
+// Handle a packet.
+// Return 0 for "not handled or accept" (so proceed as usual), or
+// -1 for "handled, don't proceeed" for drop/forward/reject (response has already been sent)
+int firewall_handle_rfc_or_brd(struct chaos_header *pkt)
+{
+  if (firewall_enabled == 0) return 0;
+
+  u_char opc = ch_opcode(pkt);
+  if ((opc != CHOP_RFC) && (opc != CHOP_BRD)) {
+    fprintf(stderr,"%%%% Firewall: not an RFC/BRD pkt: %s\n", ch_opcode_name(opc));
+    return 0;
+  }
+  char *contact_start = NULL;
+  int contact_maxlen = ch_nbytes(pkt);
+  if (ch_opcode(pkt) == CHOP_RFC)
+    contact_start = (char *)&pkt[CHAOS_HEADERSIZE];
+  else if (ch_opcode(pkt) == CHOP_BRD) {
+    // skip over broadcast bitmask
+    // @@@@ check reasonable values first
+    contact_start = (char *)&pkt[CHAOS_HEADERSIZE + ch_ackno(pkt)];
+    contact_maxlen -= ch_ackno(pkt);
+  }
+
+  u_short srcaddr = ch_srcaddr(pkt);
+  u_short destaddr = ch_destaddr(pkt);
+
+  if (debug_firewall) {
+    u_char contact[CH_PK_MAXLEN];
+    get_packet_string(pkt, contact, sizeof(contact));
+    printf("Checking %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	   ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	   ch_destaddr(pkt), ch_destindex(pkt));
+  }
+
+  for (int i = 0; i < n_firewall_rules; i++) {
+    if ((fw_rules[i]->contact_type == rule_contact_all) ||
+	((fw_rules[i]->contact_type == rule_contact_string) &&
+	 (strncasecmp(contact_start, fw_rules[i]->contact, fw_rules[i]->contact_length) == 0) &&
+	 // RFC contact is "contact" precisely or "contact args", not "contactless"
+	 (fw_rules[i]->contact_length == contact_maxlen || contact_start[fw_rules[i]->contact_length] == ' '))) {
+      struct contact_rule **rules = fw_rules[i]->rules;
+      for (int r = 0; r < fw_rules[i]->n_rules; r++) { // foreach rule
+	if (addr_match(rules[r]->rule_sources, srcaddr) && 
+	    addr_match(rules[r]->rule_dests, destaddr)) {
+	  rules[r]->rule_match_count++;
+	  // do the action
+	  return do_action(rules[r], pkt);
+	}
+      }
+      if (fw_rules[i]->contact_type != rule_contact_all) {
+	if (debug_firewall) printf("Contact matched (%s) but no rule matched, proceed\n", fw_rules[i]->contact);
+	return 0;			// Contact matched, but no rule matched, so proceed
+      }
+    }      
+  }
+  if (debug_firewall) printf("No contact matched, proceed\n");
+  return 0;			// No contact matched, so proceed
+}

--- a/firewall.c
+++ b/firewall.c
@@ -470,6 +470,7 @@ action_name(rule_action_t a)
   case rule_action_reject: return "reject";
   case rule_action_forward: return "forward";
   }
+  return "??";
 }
 static void
 print_firewall_action(struct rule_action *a)

--- a/firewall.c
+++ b/firewall.c
@@ -585,21 +585,21 @@ do_action(struct contact_rule *rule, struct chaos_header *pkt)
   switch (rule->rule_action->action) {
   case rule_action_allow:
     if (log_firewall)
-      printf("Firewall: allow %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
-	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
-	     ch_destaddr(pkt), ch_destindex(pkt));
+      fprintf(stderr,"Firewall: allow %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	      ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	      ch_destaddr(pkt), ch_destindex(pkt));
     return 0;
   case rule_action_drop:
     if (log_firewall)
-      printf("Firewall: drop %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
-	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
-	     ch_destaddr(pkt), ch_destindex(pkt));
+      fprintf(stderr,"Firewall: drop %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	      ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	      ch_destaddr(pkt), ch_destindex(pkt));
     return -1;
   case rule_action_reject:
     if (log_firewall)
-      printf("Firewall: reject %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
-	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
-	     ch_destaddr(pkt), ch_destindex(pkt));
+      fprintf(stderr,"Firewall: reject %s \"%s\" from <%#o,%#x> to <%#o,%#x>\n",
+	      ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	      ch_destaddr(pkt), ch_destindex(pkt));
     // send CLS using the pkt dest as source (but not for BRD)
     if (ch_opcode(pkt) != CHOP_BRD)
       send_cls_response(pkt, rule->rule_action->args.reject_reason);
@@ -609,10 +609,10 @@ do_action(struct contact_rule *rule, struct chaos_header *pkt)
     if (c == NULL)
       c = (char *)contact;
     if (log_firewall)
-      printf("Firewall: forward %s \"%s\" from <%#o,%#x> to <%#o,%#x>: %#o \"%s\"\n",
-	     ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
-	     ch_destaddr(pkt), ch_destindex(pkt), 
-	     rule->rule_action->args.fwd_args->forward_addr, c);
+      fprintf(stderr,"Firewall: forward %s \"%s\" from <%#o,%#x> to <%#o,%#x>: %#o \"%s\"\n",
+	      ch_opcode_name(ch_opcode(pkt)), contact, ch_srcaddr(pkt), ch_srcindex(pkt),
+	      ch_destaddr(pkt), ch_destindex(pkt), 
+	      rule->rule_action->args.fwd_args->forward_addr, c);
     // send FWD using the pkt dest as source (but not for BRD)
     if (ch_opcode(pkt) != CHOP_BRD)
       send_fwd_response(pkt, rule->rule_action->args.fwd_args->forward_addr, c);

--- a/firewall.c
+++ b/firewall.c
@@ -458,15 +458,28 @@ int parse_firewall_config_line()
   return 0;
 }
 
+static char *
+action_name(rule_action_t a)
+{
+  switch (a) {
+  case rule_action_allow: return "allow";
+  case rule_action_drop: return "drop";
+  case rule_action_reject: return "reject";
+  case rule_action_forward: return "forward";
+  }
+}
 static void
 print_firewall_action(struct rule_action *a)
 {
+  printf("%s", action_name(a->action));
   switch (a->action) {
-  case rule_action_allow: printf("allow"); return;
-  case rule_action_drop: printf("drop"); return;
-  case rule_action_reject: printf("reject \"%s\"", a->args.reject_reason); return;
+  case rule_action_reject: 
+    printf(" \"%s\"", a->args.reject_reason); 
+    break;
   case rule_action_forward: 
-    printf("forward %o \"%s\"", a->args.fwd_args->forward_addr, a->args.fwd_args->forward_contact);
+    printf(" %o \"%s\"", a->args.fwd_args->forward_addr, a->args.fwd_args->forward_contact);
+  default:
+    ;
   }
 }
 static char *

--- a/firewall.h
+++ b/firewall.h
@@ -1,0 +1,21 @@
+/* Copyright © 2024 Björn Victor (bjorn@victor.se) */
+/*  Simple firewall for cbridge, the bridge program for various Chaosnet implementations. */
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+int parse_firewall_config_line(void);
+void print_firewall_rules(void);
+
+int firewall_handle_forward(struct chaos_header *pkt);
+int firewall_handle_pkt_for_me(struct chaos_header *pkt);


### PR DESCRIPTION
A simple firewall is implemented in cbridge, where you can define how to handle connection requests (RFC and BRD packets).

It can be used e.g. to restrict access to services running on your cbridge using [the NCP interface](NCP.md), or if your cbridge is in a "gateway position", to filter packets passing through it (i.e. not necessarily with the cbridge as final destination).

## Motivation

The Chaosnet application protocols were mostly developed in a time when network users were all trustworthy, and since Chaosnet was a local area network it was easier to keep track of who had access. There was probably a bit of social control, [hacker ethics](https://en.wikipedia.org/wiki/Hacker_ethic) etc, in play.

With the [Global Chaosnet](https://chaosnet.net) this doesn't necessarily hold anymore, but retrofitting access control in many ancient programs would be a daunting task.

## Use cases

The firewall could be useful e.g. if
  - you run local `FILE` or `RTAPE` servers but don't want to give the whole Chaosnet read&write access to their contents
  - you run Lisp Machines on your network, which e.g may have servers for `EVAL`, `BAND-TRANSFER`, `REMOTE-DISK` etc which you want to protect
  - you run a `TCP` [gateway server](https://github.com/Chaosnet/chaosnet-tools) but want to avoid opening up the Chaosnet to *Evil Automated Internet Hackers*
  - you at the same time have servers for less sensitive protocols such as `NAME`, `SUPDUP`, `TELNET`, `TIME`, `UPTIME` etc, which you want to keep open and public
