### PR TITLE
Fixed time reporting incorrectly in hostat

### DIFF
--- a/bhostat.py
+++ b/bhostat.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2021-2024 Björn Victor (bjorn@victor.se)
 # Tool for exploring Chaosnet using various (simple) protocols.
 # Demonstrates the high-level python library for Chaosnet.

--- a/chaosnet.py
+++ b/chaosnet.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2023-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet support for python.
 # Demonstrates the APIs for the NCP of cbridge: both the simpler stream protocol and the packet protocol.

--- a/domain.py
+++ b/domain.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2020-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet server/forwarder for DOMAIN protocol
 # Uses the stream API of the NCP of cbridge, the bridge program for various Chaosnet implementations.

--- a/echotest.py
+++ b/echotest.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2021-2024 Björn Victor (bjorn@victor.se)
 # A little test program which sends a string of bytes (the one used by
 # BABEL) to an ECHO server and checks that the response is right, or

--- a/evactest.py
+++ b/evactest.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # A little test program.
 #
 

--- a/file.py
+++ b/file.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2020 Björn Victor (bjorn@victor.se)
 # Chaosnet client for FILE protocol
 # Demonstrates the Packet API for the NCP of cbridge, the bridge program for various Chaosnet implementations.

--- a/finger.py
+++ b/finger.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2021-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet client for NAME protocol (what is otherwise known as finger, which is a different protocol on Chaosnet)
 # Demonstrates the high-level python library for Chaosnet.

--- a/fingerd.py
+++ b/fingerd.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2021-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet server for FINGER protocol, mainly used by Lisp Machines.
 # (NOT what is otherwise known as finger, but a different protocol on Chaosnet.)

--- a/hostab.py
+++ b/hostab.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2024 Björn Victor (bjorn@victor.se)
 # A client program for the HOSTAB protocol.
 

--- a/hostabd.py
+++ b/hostabd.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2023-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet server for HOSTAB protocol.
 # As an extension, the request can also be a Chaosnet address (octal), which is looked up

--- a/hostat.c
+++ b/hostat.c
@@ -213,7 +213,10 @@ void print_time(u_char *bp, int len, u_short src, int verbose)
 
   if (len != 4) { printf("Bad time length %d (expected 4)\n", len); exit(1); }
 
-  time_t t = (u_short)(*dp++); t |= (u_long) ((u_short)(*dp)<<16);
+  u_long gt = ((u_long)bp[3]<<24) + ((u_long)bp[2]<<16) + ((u_long)bp[1]<<8) + ((u_long)bp[0]);
+  time_t t = gt;
+  //time_t t = (u_short)(*dp++); t |= (u_long) ((u_short)(*dp)<<16);
+
   time_t here = time(NULL);
 #if __APPLE__
   // imagine this

--- a/loadd.py
+++ b/loadd.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2022-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet server for LOAD protocol, mainly used by ITS.
 # This is a simple protocol with returns a string a'la "Fair Share: X%\r\nUsers: N."

--- a/named.py
+++ b/named.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2021-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet server for NAME protocol (what is otherwise known as finger, which is a different protocol on Chaosnet)
 # Demonstrates the APIs for the NCP of cbridge: both the simpler stream protocol and the packet protocol.

--- a/spy.py
+++ b/spy.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2024 Björn Victor (bjorn@victor.se)
 # Chaosnet client for SPY protocol, to see the screen of a LISPM.
 # Demonstrates the high-level python library for Chaosnet,

--- a/telnet.py
+++ b/telnet.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Copyright © 2022-2024 Björn Victor (bjorn@victor.se)
 # Chaosnet client for TELNET protocol (not SUPDUP, just to keep it simple for now)
 # Demonstrates the high-level python library for Chaosnet.


### PR DESCRIPTION
On my builds of hostat the date would show as 1888,  this is due to the way the endianness happens for ints.   Corrected by shifting each byte into a u_long