### PR TITLE
More debuggable errors + TLS accept timeout

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -101,7 +101,7 @@ Link and route defs take optional arguments.
 
 - `mux` *%o-list*
 
-    For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (currently 4, see `CHTLS_MAXMUX`).
+    For TLS links *only*, an additional parameter `mux` can be used to multiplex more hosts (e.g. a KLH10) over a single TLS connection, without requiring a separate subnet to be allocated. See [an example config](EXAMPLES.md). The argument *%o-list* is a comma-separated list of octal Chaosnet addresses (note: no spaces allowed, only commas). A maximum limit for the number of multiplexed addresses exists (currently 16, see `CHTLS_MAXMUX`).
     **NOTE** that the "muxed" addresses *must* be on the same subnet as the TLS link, and *each* must be directly reachable through (individual) links, defined *before* the TLS link. *Note*: If the link to the muxed address is a `subnet` link (rather than a `host` link), routing might break.
 
 ### LINKTYPE:

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -33,7 +33,7 @@ Below, *%o* means an octal number, and square brackets [ ] are around optional p
 - `chudp` *portnr* [`dynamic` \| `static` \| `ipv6` \| `debug` off/on ]
 
 	set my chudp portnr (default 42042). If `dynamic`, add new chudp links [dynamically](#dynamic-links-and-routes) when receiving pkts from unknown sources. With ipv6 option, listens to both v4 and v6 (enabled also by defining a chudp link where the host has an ipv6 addr). With debug on, prints some debug stuff. 
-- `tls` [ `key` *keyfile* ] [ `cert` *certfile* ] [ `ca-chain` *ca-chain-cert-file* ] [ `myaddrs` *list* ] [ `server` *portnr* ] [ `debug` off/on ] [ `expirywarn `*days* ] [ `crl` *crlfile* ]
+- `tls` [ `key` *keyfile* ] [ `cert` *certfile* ] [ `ca-chain` *ca-chain-cert-file* ] [ `myaddrs` *list* ] [ `server` *portnr* ] [ `debug` off/on ] [ `expirywarn `*days* ] [ `crl` *crlfile* ] [ `accept_timeout` *%d* ]
 
 	set up for TLS using the private key in *keyfile*, the cert in *certfile*, and the CA trust chain in *ca-chain-cert-file*. If `server` is specified, a TLS server is started listening to *portnr* (default 42042, if at EOL). This requires a server certificate. TLS servers are always "dynamic" in that they listen to connections from anywhere, but accept only those using certificates trusted by the CA trust chain. Server-end connections are added dynamically at runtime, and can not be pre-declared. 
 
@@ -42,6 +42,8 @@ Below, *%o* means an octal number, and square brackets [ ] are around optional p
 	With debug on, prints some debug stuff.  `expirywarn` defaults to 90, the number of days before certificate expiry to start whining about it.
 	
 	The `crl` parameter specifies a Certificate Revocation List file, supplied by the CA you use. This is encouraged, in particular if you are running a TLS server. You will need to update it regularly (a warning is printed about this). See the [TLS documentation](TLS.md#certificate-revocation-list-crl) for more info.
+	
+	The `accept_timeout` setting specifies the number of seconds to wait for an incoming TCP connection to complete an initial SSL negotiation (by means of `SSL_accept`). The timeout value should be small but not too small (default 5). This setting is only meaningful when setting up a TLS server. The timeout stops robots that connect to the server port from using up valuable resources in cbridge.
 - `ether` [ `debug` off/on ]
 
 	With debug on, prints some debug stuff. (Note that interface names are now on link definitions.) 

--- a/cbridge.c
+++ b/cbridge.c
@@ -268,7 +268,7 @@ u_short find_closest_addr(u_short haddrs[], int naddrs)
   int i, a;
   if (naddrs <= 0) {
     fprintf(stderr,"find_closest_addr called with %d addresses to search\n", naddrs);
-    exit(1);
+    abort();
   }
   if (naddrs == 1)
     // only one choice
@@ -2274,14 +2274,14 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr, "Starting thread for UNIX socket\n");
     if ((e = pthread_create(&threads[ti++], NULL, &unix_input, NULL)) != 0) {
       fprintf(stderr,"pthread_create(unix_input): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
   if (do_udp) {
     if (verbose) fprintf(stderr, "Starting thread for UDP sockets\n");
     if ((e = pthread_create(&threads[ti++], NULL, &chudp_input, &do_udp6)) != 0) {
       fprintf(stderr,"pthread_create(chudp_input): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
 #if CHAOS_ETHERP
@@ -2289,7 +2289,7 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting thread for Ethernet\n");
     if ((e = pthread_create(&threads[ti++], NULL, &ether_input, NULL)) != 0) {
       fprintf(stderr,"pthread_create(ether_input): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
 #endif // CHAOS_ETHERP
@@ -2298,7 +2298,7 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting thread for Chaos-over-IP\n");
     if ((e = pthread_create(&threads[ti++], NULL, &chip_input, NULL)) != 0) {
       fprintf(stderr,"pthread_create(chip_input): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
 #endif
@@ -2313,14 +2313,14 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting thread for TLS server\n");
     if ((e = pthread_create(&threads[ti++], NULL, &tls_server, NULL)) != 0) {
       fprintf(stderr,"pthread_create(tls_server): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
   if (do_tls || do_tls_server) {
     if (verbose) fprintf(stderr,"Starting thread for TLS input\n");
     if ((e = pthread_create(&threads[ti++], NULL, &tls_input, NULL)) != 0) {
       fprintf(stderr,"pthread_create(tls_input): %s", strerror(e));
-      exit(1);
+      abort();
     }
     int i;
     for (i = 0; i < tlsdest_len; i++) {
@@ -2328,7 +2328,7 @@ main(int argc, char *argv[])
 	if (verbose) fprintf(stderr,"Starting thread for TLS client connector %d\n", i);
 	if ((e = pthread_create(&threads[ti++], NULL, &tls_connector, &tlsdest[i])) != 0) {
 	  fprintf(stderr,"pthread_create(tls_connector %d): %s", i, strerror(e));
-	  exit(1);
+	  abort();
 	}
       }
     }    
@@ -2339,7 +2339,7 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting thread for DNS forwarder\n");
     if ((e = pthread_create(&threads[ti++], NULL, &dns_forwarder_thread, NULL)) != 0) {
       fprintf(stderr,"pthread_create(dns_forwarder_thread): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
 #endif
@@ -2350,7 +2350,7 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting RUT sender thread\n");
     if ((e = pthread_create(&threads[ti++], NULL, &rut_sender, NULL)) != 0) {
       fprintf(stderr,"pthread_create(rut_sender): %s", strerror(e));
-      exit(1);
+      abort();
     }
   } else {
     if (verbose) fprintf(stderr,"Not starting RUT sender thread: only %d network%s, %d host link%s\n",
@@ -2361,7 +2361,7 @@ main(int argc, char *argv[])
   if (verbose) fprintf(stderr,"Starting route cost updating thread\n");
   if ((e = pthread_create(&threads[ti++], NULL, &route_cost_updater, NULL)) != 0) {
     fprintf(stderr,"pthread_create(route_cost_updater): %s", strerror(e));
-    exit(1);
+    abort();
   }
   if (do_udp || do_udp6
 #if CHAOS_IP
@@ -2371,7 +2371,7 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting hostname re-parsing thread\n");
     if ((e = pthread_create(&threads[ti++], NULL, &reparse_link_host_names_thread, NULL)) != 0) {
       fprintf(stderr,"pthread_create(reparse_link_host_names_thread): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
 
@@ -2379,7 +2379,7 @@ main(int argc, char *argv[])
     if (verbose) fprintf(stderr,"Starting NCP\n");
     if ((e = pthread_create(&threads[ti++], NULL, &ncp_user_server, NULL)) != 0) {
       fprintf(stderr,"pthread_create(ncp_user_server): %s", strerror(e));
-      exit(1);
+      abort();
     }
   }
 
@@ -2387,7 +2387,7 @@ main(int argc, char *argv[])
   for (int i = 0; i < ti; i++) {
     if ((e = pthread_detach(threads[i])) != 0) {
       fprintf(stderr,"pthread_detach (thread %d): %s\n", i, strerror(e));
-      exit(1);
+      abort();
     }
   }
 

--- a/cbridge.h
+++ b/cbridge.h
@@ -156,7 +156,7 @@ struct chroute {
   time_t rt_cost_updated;	/* cost last updated */
 #if CHAOS_TLS
 // Number of addresses we can multiplex on a connection
-#define CHTLS_MAXMUX 4
+#define CHTLS_MAXMUX 16
   u_short rt_tls_muxed[CHTLS_MAXMUX]; /* Other addresses we're muxing for */
 #endif
 };

--- a/chether.c
+++ b/chether.c
@@ -506,7 +506,7 @@ get_packet_socket(u_short ethtype, struct chethdest *cd)
   pfp->bf_len = p - pfp->bf_insns; /* length of program */
   if (pfp->bf_len > BPF_PFMAX) {
     fprintf(stderr,"BPF: filter program too long, increase BPF_PFMAX!\n");
-    exit(1);
+    abort();
   }
 
   if (ioctl(fd, BIOCSETF, (char *)pfp) < 0) {
@@ -721,7 +721,7 @@ send_packet(struct chethdest *cd, int if_fd, u_short ethtype, u_char *addr, u_ch
     {
       perror("send_packet");
       fprintf(stderr, "\n");
-      exit(1);
+      abort();
     }
 }
 
@@ -795,7 +795,7 @@ get_packet(struct chethdest *cd, int if_fd, u_char *buf, int buflen)
     protocol = ntohs(ETHERTYPE_CHAOS);
   else {
     fprintf(stderr,"get_packet: bad FD\n");
-    exit(1);
+    abort();
   }
 
 #if 0 //debug
@@ -822,7 +822,7 @@ get_packet(struct chethdest *cd, int if_fd, u_char *buf, int buflen)
 		  buflen, BPF_MTU);
 	}
 #endif
-	exit(1);
+	abort();
       }
       else if (chether_debug || debug) perror("read BPF ether");
       return 0;
@@ -916,7 +916,7 @@ get_packet(struct chethdest *cd, int if_fd, u_char *buf, int buflen)
     {
       if (errno != EAGAIN) {
 	perror ("get_packet: Read error");
-	exit(1);
+	abort();
       }
       return 0;
     }
@@ -1346,9 +1346,9 @@ ether_input(void *v)
   get_my_ea();
   for (i = 0; i < nchethdest; i++) {
     if ((chethdest[i].cheth_arpfd = get_packet_socket(ETHERTYPE_ARP, &chethdest[i])) < 0)
-      exit(1);
+      abort();
     if ((chethdest[i].cheth_chfd = get_packet_socket(ETHERTYPE_CHAOS, &chethdest[i])) < 0)
-      exit(1);
+      abort();
   }
 
   /* Ether -> others thread */

--- a/chip.c
+++ b/chip.c
@@ -248,14 +248,14 @@ init_chaos_ip()
   int one = 1;
   if ((ip_sock = socket(AF_INET, SOCK_RAW, IPPROTO_CHAOS)) < 0) {
     perror("socket(AF_INET, SOCK_RAW, IPPROTO_CHAOS)");
-    exit(1);
+    abort();
   } 
   // need to be able to use broadcast, for subnet mappings
   if (setsockopt(ip_sock, SOL_SOCKET, SO_BROADCAST, &one, sizeof(one)) < 0)
     perror("setsockopt(ipv4, SO_BROADCAST)");
   if ((ip6_sock = socket(AF_INET6, SOCK_RAW, IPPROTO_CHAOS)) < 0) {
     perror("socket(AF_INET6, SOCK_RAW, IPPROTO_CHAOS)");
-    exit(1);
+    abort();
   } 
 }
 

--- a/chtls.c
+++ b/chtls.c
@@ -1229,6 +1229,74 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
   return actual;
 }
 
+// SSL_accept with timeout.
+// This seems to be useful to counteract internet-measurement.com, which sometimes connects to the server port
+// without performing a TLS handshake (how would it know it should), hanging and consuming resources, eventually
+// crashing cbridge (don't know where/how, yet).
+// See https://stackoverflow.com/questions/11835203/openssl-ssl-connect-blocks-forever-how-to-set-timeout.
+// ("The OpenSSL Library gives you the maximum flexibility in terms of handling socket related issues" - rubbish!)
+//
+// This does not help against someone connecting, and then sending < 4 bytes (which triggers the SSL_accept),
+// and then hanging there (which makes the SSL_accept hang). Using SO_RCVTIMEO seems even more awkward than the
+// current approach though, and using thread-local timers seems "an area under development" still?
+static int
+ssl_accept_with_timeout(SSL *ssl)
+{
+  // Is there available data already?
+  if (SSL_pending(ssl) > 0) {
+    if (tls_debug) fprintf(stderr,"%s: already pending data\n", __func__);
+    return SSL_accept(ssl);	// then just try to use it
+  }
+
+  // Else hairier: set non-blocking, use select with timeout, and check again, before trying SSL_accept
+  int fd = SSL_get_fd(ssl);
+  // Make sure the socket is nonblocking
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags < 0)
+    flags = 0;
+  if (fcntl(fd, F_SETFL, flags|O_NONBLOCK) < 0) {
+    perror("fcntl(F_SETFL)");
+    abort();
+  }
+  fd_set fds;
+  int ntries = 0;
+  while (ntries < 3) {		// @@@@ try this - but the loop shouldn't be needed really
+    FD_ZERO(&fds);
+    FD_SET(fd, &fds);
+    struct timeval timeout;
+    timeout.tv_usec = 0;
+    timeout.tv_sec = 3;		// @@@@ try this
+    int sval = select(fd+1, &fds, NULL, NULL, &timeout);
+    if (sval < 0) {
+      perror("select(ssl_accept_with_timeout)");
+      abort();
+    } else if (sval > 0) {
+      // There is something to read
+      if (fcntl(fd, F_SETFL, flags) < 0) { // restore flags
+	perror("fnctl(ssl_accept_with_timeout)");
+	abort();
+      }
+      // @@@@ odd: pending and has_pending are typically both 0 in cases where the connections is a proper TLS connection.
+      // Treating that as timeout makes the TLS connection fail (after N tries in this loop).
+      if (tls_debug) fprintf(stderr,"%s: try %d: data exists, pending=%d, has_pending=%d, trying SSL_accept\n", __func__, ntries,  
+			     SSL_pending(ssl), SSL_has_pending(ssl));
+      // @@@@ will hang if < 4 bytes available.
+      return SSL_accept(ssl);
+    } else {
+      // timed out, loop back
+      if (tls_debug) fprintf(stderr,"%s: try %d: time out, try again\n", __func__, ntries);
+      ntries++;
+    }
+  }
+  // Tried N times without success, fail
+  if (tls_debug) fprintf(stderr,"%s: tried %d times, failing\n", __func__, ntries);
+  if (fcntl(fd, F_SETFL, flags) < 0) { // restore flags
+    perror("fnctl(ssl_accept_with_timeout)");
+    abort();
+  }
+  return -1;
+}
+
 // TLS server thread.
 // Bind a socket, listen, and loop accepting valid TLS connections.
 void * 
@@ -1288,7 +1356,7 @@ tls_server(void *v)
     int v = 0;
     ERR_clear_error();		/* try to get the latest error below, not some old */
     fprintf(stderr,"%%%% TLS server calling SSL_accept\n");
-    if ((v = SSL_accept(ssl)) <= 0) {
+    if ((v = ssl_accept_with_timeout(ssl)) <= 0) {
       fprintf(stderr,"%%%% TLS server SSL_accept failed\n");
       // this already catches verification - client end gets "SSL alert number 48"?
       int err = SSL_get_error(ssl, v);

--- a/chtls.c
+++ b/chtls.c
@@ -1287,7 +1287,9 @@ tls_server(void *v)
     }
     int v = 0;
     ERR_clear_error();		/* try to get the latest error below, not some old */
+    printf("%%%% TLS server calling SSL_accept\n");
     if ((v = SSL_accept(ssl)) <= 0) {
+      printf("%%%% TLS server SSL_accept failed\n");
       // this already catches verification - client end gets "SSL alert number 48"?
       int err = SSL_get_error(ssl, v);
       if (err != SSL_ERROR_SSL) {
@@ -1313,6 +1315,7 @@ tls_server(void *v)
       SSL_free(ssl);
       continue;
     }      
+    printf("%%%% TLS server SSL_accept success\n");
 
     X509 *ssl_client_cert = SSL_get_peer_certificate(ssl);
 

--- a/chtls.c
+++ b/chtls.c
@@ -1287,9 +1287,9 @@ tls_server(void *v)
     }
     int v = 0;
     ERR_clear_error();		/* try to get the latest error below, not some old */
-    printf("%%%% TLS server calling SSL_accept\n");
+    fprintf(stderr,"%%%% TLS server calling SSL_accept\n");
     if ((v = SSL_accept(ssl)) <= 0) {
-      printf("%%%% TLS server SSL_accept failed\n");
+      fprintf(stderr,"%%%% TLS server SSL_accept failed\n");
       // this already catches verification - client end gets "SSL alert number 48"?
       int err = SSL_get_error(ssl, v);
       if (err != SSL_ERROR_SSL) {
@@ -1315,7 +1315,7 @@ tls_server(void *v)
       SSL_free(ssl);
       continue;
     }      
-    printf("%%%% TLS server SSL_accept success\n");
+    fprintf(stderr,"%%%% TLS server SSL_accept success\n");
 
     X509 *ssl_client_cert = SSL_get_peer_certificate(ssl);
 

--- a/chtls.c
+++ b/chtls.c
@@ -1334,6 +1334,7 @@ tls_server(void *v)
       fprintf(stderr,"SSL_set_fd failed (server, tsock %d): ", tsock);
       ERR_print_errors_fp(stderr);
       close(tsock);
+      SSL_free(ssl);
       continue;
     }
     int v = 0;

--- a/chudp.c
+++ b/chudp.c
@@ -149,7 +149,7 @@ static int chudp_connect(u_short port, sa_family_t family)
 
   if ((sock = socket(family, SOCK_DGRAM, 0)) < 0) {
     perror("socket failed");
-    exit(1);
+    abort();
   }
   if (family == AF_INET6) {
     struct sockaddr_in6 sin6;
@@ -161,7 +161,7 @@ static int chudp_connect(u_short port, sa_family_t family)
     memcpy(&sin6.sin6_addr, &in6addr_any, sizeof(in6addr_any));
     if (bind(sock, (struct sockaddr *)&sin6, sizeof(sin6)) < 0) {
       perror("bind(v6) failed");
-      exit(1);
+      abort();
     }
   } else {
     struct sockaddr_in sin;
@@ -170,7 +170,7 @@ static int chudp_connect(u_short port, sa_family_t family)
     sin.sin_addr.s_addr = INADDR_ANY;
     if (bind(sock,(struct sockaddr *)&sin, sizeof(sin)) < 0) {
       perror("bind failed");
-      exit(1);
+      abort();
     }
   }
   return sock;
@@ -223,7 +223,7 @@ chudp_send_pkt(int sock, struct sockaddr *sout, unsigned char *buf, int len)
     if (verbose || debug)
       perror("sendto failed");
 #if 0 // don't die here, some link may be down. Ideally don't retry until "later"
-    exit(1);
+    abort();
 #endif
   }
 }
@@ -297,7 +297,7 @@ chudp_receive(int sock, unsigned char *buf, int buflen)
   cnt = recvfrom(sock, buf, buflen, 0, (struct sockaddr *) &sin, &sinlen);
   if (cnt < 0) {
     perror("recvfrom");
-    exit(1);
+    abort();
   }
   if (inet_ntop(sin.sin6_family,
 		(sin.sin6_family == AF_INET ? (void *)&((struct sockaddr_in *)&sin)->sin_addr
@@ -480,7 +480,7 @@ chudp_input(void *v)
     int e = pthread_detach(subthreads[i]);
     if (e != 0) {
       fprintf(stderr,"pthread_detach (chudp thread %d): %s\n", i, strerror(e));
-      exit(1);
+      abort();
     }
   }
   while (1) {

--- a/pkqueue.c
+++ b/pkqueue.c
@@ -126,7 +126,7 @@ pkqueue_add(struct chaos_header *pkt, struct pkqueue *q)
   // make new element
   nl = (struct pkt_elem *)malloc(sizeof(struct pkt_elem)); // new last
   if (nl == NULL) {
-    perror("malloc(pkt_elem)"); exit(1);
+    perror("malloc(pkt_elem)"); abort();
   }
   nl->pkt = pkt;
   nl->transmitted.tv_sec = 0;
@@ -159,7 +159,7 @@ pkqueue_insert_by_packetno(struct chaos_header *pkt, struct pkqueue *q)
 
   nl = (struct pkt_elem *)malloc(sizeof(struct pkt_elem)); // new last
   if (nl == NULL) {
-    perror("malloc(pkt_elem)"); exit(1);
+    perror("malloc(pkt_elem)"); abort();
   }
   nl->pkt = pkt;
   nl->transmitted.tv_sec = 0;

--- a/usockets.c
+++ b/usockets.c
@@ -215,7 +215,7 @@ void * unix_input(void *v)
   }
 
   if ((unixsock = u_connect_to_server()) < 0) {
-    //exit(1);
+    //abort();
     if (verbose || unixdebug)
       fprintf(stderr,"Warning: couldn't open unix socket - check if chaosd is running?\n");
   }


### PR DESCRIPTION
1. Use abort() instead of exit(1) in places where errors are "unexpected".
2. Add a timeout to the initial TLS negotiation (SSL_accept), and make the timeout configurable.
3. Increase the limit for how many hosts can multiplex a TLS connection (`CHTLS_MAXMUX`).

The idea with (1) would be that abort() generates a core dump (if `ulimit -c unlimited` has been used), although for me it still doesn't if running as root (and updating `fs.suid_dumpable`, `kernel.core_pattern`, and/or using `prctl(PR_SET_DUMPABLE, 1);`). Any help would be appreciated.

The idea with (2) is that robots/scanners that connect to the TLS port, but then do nothing, use up valuable resources in a "DoS"-y way. By adding the timeout, they are quickly disconnected.

Number 3 is unrelated. ;-)

Still after this, there are occasions where cbridge silently terminates. :-(