### PR TITLE
Use libbind on macOS, rather than libresolv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 OS_NAME = $(shell uname)
 MACH_NAME = $(shell uname -m)
 
+# default
+LIBRESOLV=-lresolv
+
 # Mac OSX
 ifeq ($(OS_NAME), Darwin)
-CFLAGS = -I/opt/local/include -g
+# To make chaosnet dns work in 15.4, you should install libbind (which needs tbl which comes with groff)
+CFLAGS = -I/opt/local/include/bind -I/opt/local/include -g
 LDFLAGS = -L/opt/local/lib
+LIBRESOLV = -lbind
 else
 CFLAGS = -g
 endif
-
-LIBRESOLV=-lresolv
 
 # For OpenBSD, do "pkg_add libbind"
 ifeq ($(OS_NAME), OpenBSD)

--- a/NCP.md
+++ b/NCP.md
@@ -4,6 +4,8 @@ The NCP implements the "transport layer" of Chaosnet, and lets a regular user pr
 
 You can also use it to make your "unix-like" host a Chaosnet node, by using and adding applications connected to the Chaosnet, such as file transfer, interactive terminal sessions, etc.
 
+For convenient Chaosnet DNS use on macOS 15.4 (and perhaps higher), install `libbind` (which needs `tbl` which comes with `groff`).
+
 # Configuration
 
 `ncp ` [ `enabled` no/yes ] [ `debug` off/on ] [ `trace` off/on ]  ...

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Requires `libssl-dev` to compile on Linux; on Mac with `port`, install `openssl`
 
 A simple unix sockets interface ("API") for connecting "any old program" to Chaosnet, e.g. Supdup. See [the docs](NCP.md) and [Supdup for Chaosnet](https://github.com/PDP-10/supdup). There is also a higher-level Python library.
 
+For convenient Chaosnet DNS use on macOS 15.4 (and perhaps higher), install `libbind` (which needs `tbl` which comes with `groff`).
+
 ## Routing basics
 
 When configuring your Chaosnets, you should really think about routing

--- a/cbridge.c
+++ b/cbridge.c
@@ -1481,7 +1481,12 @@ parse_ip_params(char *type, struct sockaddr *sa, int default_port, char *nameptr
   struct addrinfo *he, hints;
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
-  hints.ai_flags = AI_ADDRCONFIG;
+#ifdef AI_ADDRCONFIG		// Use AI_ADDRCONFIG if appropriate
+#ifdef AI_MASK			// and it is a valid flag
+  if (AI_MASK & AI_ADDRCONFIG)
+#endif
+    hints.ai_flags = AI_ADDRCONFIG;
+#endif
 
   tok = strtok(NULL," \t\r\n");
   if (default_port > 0) {


### PR DESCRIPTION
Using libresolv, `res_nquery` (for Chaosnet-class records) fails on macOS 15.4.
The query is sent OK, the answer received OK, but isn't handled: with RES_DEBUG, you get

```res_send: recvfrom: Invalid argument```

**The effect** is for example that `supdup` *hostname* fails with "unknown host", or tries to connect using TCP (if *hostname* has an IP address). Annoying.

**Analysis**:
In [libresolv](https://github.com/apple-oss-distributions/libresolv/tree/libresolv-83), the call chain is `res_nquery -> res_nsend -> dns_res_send -> send_dg -> internet_recvfrom -> recvmsg`,
and `recvfrom` returns 0 as `msg_controllen` (no ancilliary data), which is seen as an error in `libresolv` but is normal
least for macOS, see https://stackoverflow.com/questions/48861927/how-do-i-get-the-size-of-the-msg-control-buffer-for-recvmsg).

**Possible fixes**:
1.  patch [`internal_recvfrom`](https://github.com/apple-oss-distributions/libresolv/blob/ba47e8e44aa2f145424caf4f7e1a87facefb1175/res_send.c#L1116) in libresolv to [accept 0 for `msg_controllen`](https://github.com/apple-oss-distributions/libresolv/blob/ba47e8e44aa2f145424caf4f7e1a87facefb1175/res_send.c#L1138), and use that. This is awkward e.g. because `__NAMESER` differs between [libresolv sources](https://github.com/apple-oss-distributions/libresolv/blob/ba47e8e44aa2f145424caf4f7e1a87facefb1175/nameser.h#L78) and the macOS /usr/include/nameser.h (so the sources probably don't match the OS distro).
2. or install `libbind`, which is more modern and works. T[he current MacPorts "port" of `libbind`](https://ports.macports.org/port/libbind/) however breaks when building  unless `groff` is installed (since it needs `tbl` but doesn't have `groff` (which contains `tbl`) as a dependency).

This PR uses fix (2), and adjusts the Makefile and a few other things to work with libbind.

Note that after this PR, you need `port install libbind` (or equivalent) on macOS. If the install fails, you probably didn't have `groff` installed, so `port install groff` followed by `port clean libbind` and `port install libbind` would be needed.

Side notes: 
1. I'm pretty sure all this used to work before macOS 15.4, which seems a bit surprising given that even the OLD libresolv code has the bad behaviour.
2. I'm not sure if the problem is related to using the Chaosnet DNS class, and why, but I'm too lazy to check.