### PR TITLE
TLS server redundancy

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -179,7 +179,7 @@ This made the network structure contradictory to the Chaosnet principle of "[no 
 For increased redundancy, the dependence on a central hub can be removed. Two (or more) TLS servers for a subnet can cooperate, all of them accepting clients. If a packet arrives at one of them, but the server does not have a direct TLS link to the destination, it can send it to another of the subnet servers. The next server might have a direct link to the destination, or pass the packet along to another server. If none have a direct link to the destination, the [forwarding count](https://chaosnet.net/amber.html#Routing) for the packet will eventually reach its maximum and the packet is dropped.
 
 ### Server configuration
-For servers with only incoming TLS links *but are part of such a set of subnet servers*, the route to the "next" subnet server needs to be configured manually using e.g.
+For servers with only incoming TLS links for the particular subnet, and have "secondary" servers for the subnet (see "Other servers" below), the route to the "next" subnet server needs to be configured manually using e.g.
 
     route subnet 6 bridge NNNN link tls
 

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -173,32 +173,33 @@ unless there is an existing static route.
 
 ## Using a TLS "hub" network
 
-The Global Chaosnet until 2025 used a central hub for subnet 6 which is a TLS server, and clients with a proper certificate can connect to it, adding connectivity to their local subnets.
-This made the network structure contradictory to the Chaosnet principle of "[no central control](https://chaosnet.net/amber.html#Introduction)", and sensitive to crashes or errors at the central hub.
+Until August 2025, the Global Chaosnet used a central hub for subnet 6 which is a TLS server, and clients with a proper certificate can connect to it, adding connectivity to their local subnets.
+The use of a central hub made the network structure contradictory to the Chaosnet principle of "[no central control](https://chaosnet.net/amber.html#Introduction)", and sensitive to crashes or errors at the central hub.
 
 For increased redundancy, the dependence on a central hub can be removed. Two (or more) TLS servers for a subnet can cooperate, all of them accepting clients. If a packet arrives at one of them, but the server does not have a direct TLS link to the destination, it can send it to another of the subnet servers. The next server might have a direct link to the destination, or pass the packet along to another server. If none have a direct link to the destination, the [forwarding count](https://chaosnet.net/amber.html#Routing) for the packet will eventually reach its maximum and the packet is dropped.
 
-### Server configuration
-For servers with only incoming TLS links for the particular subnet, and have "secondary" servers for the subnet (see "Other servers" below), the route to the "next" subnet server needs to be configured manually using e.g.
+### Client configuration
+**Normal (non-server) TLS clients** connecting to any of the servers will dynamically/automatically configure their routes (so no manual `route` config is needed).
+
+If the host name used in a `link tls` configuration has more than one IPv4/IPv6 address, they will be tried in a round-robin manner when connecting. This e.g. means that if/when `router.chaosnet.net` has the addresses of all the subnet servers for net 6, a client needs only use
+
+    link tls router.chaosnet.net host unknown myaddr NNNN
+
+(where *NNNN* is the client's Chaosnet address) and will be connected to the first of the subnet servers that is available (in case they are not all available).
+
+### Server configuration (hub servers)
+
+For servers with **only incoming** TLS links for the particular subnet, and have "secondary" servers for the subnet (see "Other servers" below), the route to the "next" subnet server needs to be configured manually using e.g.
 
     route subnet 6 bridge NNNN link tls
 
 (where *NNNN* is the Chaosnet address of the "next" subnet server). Note that `link tls` is necessary for the route to be used also before/when the TLS link to *NNNN* is not up (yet). Note also that if the server is the only TLS server for a subnet, no such manual `route` configuration is necessary or desired.
 
-Other servers, with active/client TLS links to its "next" server, e.g. with
+**Other servers**, with active/client TLS links to its "next" server, e.g. with
 
     link tls next.chaosnet.net host MMMM myaddr NNNN
 
 will dynamically/automatically configure their routes when (a) the TLS connection is up, and (b) the other server sends routing info about the net.
-
-### Client configuration
-**Normal (non-server) TLS clients** connecting to any of the servers will also dynamically/automatically configure their routes, so no manual `route` config is needed.
-
-For added convenience, if the host name used in a `link tls` configuration has more than one IPv4/IPv6 address, they will be tried in a round-robin manner when connecting. This e.g. means that if/when `router.chaosnet.net` has the addresses of all the subnet servers for net 6, a client needs only use
-
-    link tls router.chaosnet.net host unknown myaddr NNNN
-
-(where *NNNN* is the client's Chaosnet address) and will be connected to the first of the subnet servers that is available (in case they are not all available).
 
 ### If you find this confusing
 Please let me know so I can explain better! :-)

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -178,11 +178,12 @@ This made the network structure contradictory to the Chaosnet principle of "[no 
 
 For increased redundancy, the dependence on a central hub can be removed. Two (or more) TLS servers for a subnet can cooperate, all of them accepting clients. If a packet arrives at one of them, but the server does not have a direct TLS link to the destination, it can send it to another of the subnet servers. The next server might have a direct link to the destination, or pass the packet along to another server. If none have a direct link to the destination, the [forwarding count](https://chaosnet.net/amber.html#Routing) for the packet will eventually reach its maximum and the packet is dropped.
 
-For servers with only incoming TLS links, the route to the "next" subnet server needs to be configured manually using e.g.
+### Server configuration
+For servers with only incoming TLS links *but are part of such a set of subnet servers*, the route to the "next" subnet server needs to be configured manually using e.g.
 
     route subnet 6 bridge NNNN link tls
 
-(where *NNNN* is the Chaosnet address of the "next" subnet server). Note that `link tls` is necessary for the route to be used also before/when the TLS link to *NNNN* is not up (yet).
+(where *NNNN* is the Chaosnet address of the "next" subnet server). Note that `link tls` is necessary for the route to be used also before/when the TLS link to *NNNN* is not up (yet). Note also that if the server is the only TLS server for a subnet, no such manual `route` configuration is necessary or desired.
 
 Other servers, with active/client TLS links to its "next" server, e.g. with
 
@@ -190,6 +191,7 @@ Other servers, with active/client TLS links to its "next" server, e.g. with
 
 will dynamically/automatically configure their routes when (a) the TLS connection is up, and (b) the other server sends routing info about the net.
 
+### Client configuration
 **Normal (non-server) TLS clients** connecting to any of the servers will also dynamically/automatically configure their routes, so no manual `route` config is needed.
 
 For added convenience, if the host name used in a `link tls` configuration has more than one IPv4/IPv6 address, they will be tried in a round-robin manner when connecting. This e.g. means that if/when `router.chaosnet.net` has the addresses of all the subnet servers for net 6, a client needs only use
@@ -197,3 +199,6 @@ For added convenience, if the host name used in a `link tls` configuration has m
     link tls router.chaosnet.net host unknown myaddr NNNN
 
 (where *NNNN* is the client's Chaosnet address) and will be connected to the first of the subnet servers that is available (in case they are not all available).
+
+### If you find this confusing
+Please let me know so I can explain better! :-)

--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -188,11 +188,6 @@ use) an address specific to each net.
 
     link ether eth0 subnet 1 myaddr 440
 
-To tell cbridge to send routing info about net 6, which only has
-individual host links, a route declaration is necessary. You will probably never need this, and it is a bug that it is sometimes needed.
-
-    route subnet 6 bridge 3040 cost asynch
-
 ## Example: Chaos-over-IP
 
 To set up an individual link to another host (a chaosnet bridge, or perhaps a PDP-10/X) using Chaos-over-IP, use

--- a/src/cbridge.c
+++ b/src/cbridge.c
@@ -1261,9 +1261,10 @@ parse_route_params(struct chroute *rt, u_short addr)
   rt->rt_cost = RTCOST_ETHER;	/* default */
   rt->rt_link = LINK_NOLINK;
 
-#if 0				// allow (subnet) routes where the bridge is not (yet) reachable
+  // find (individual) host route to the bridge specified
   struct chroute *brt = find_in_routing_table(rt->rt_braddr, 1, 1);
   if (brt != NULL) {
+    // copy the link and cost
     rt->rt_link = brt->rt_link;
     rt->rt_cost = brt->rt_cost;
   } else if (is_mychaddr(rt->rt_braddr) && RT_SUBNETP(rt)) {
@@ -1282,6 +1283,7 @@ parse_route_params(struct chroute *rt, u_short addr)
       }
     }
     PTUNLOCKN(rttbl_lock,"rttbl_lock");
+#if 0				// allow (subnet) routes where the bridge is not (yet) reachable
     if (rt->rt_link == LINK_NOLINK) {
       fprintf(stderr,"route to %#o: can't find matching link, thus link implementation is unknown.\n"
 	      "%%%% No route added! Maybe you need to reorder your config?\n",
@@ -1291,8 +1293,8 @@ parse_route_params(struct chroute *rt, u_short addr)
     fprintf(stderr,"route to %#o: can't find route to its bridge %#o, thus link is unknown.\n"
 	    "%%%% No route added! Try to reorder your config - put \"route\" definitions after \"link\" definitions.\n",
 	    rt->rt_dest, rt->rt_braddr);
-  }
 #endif
+  }
 
   while ((tok = strtok(NULL, " \t\r\n")) != NULL) {
     if (strcasecmp(tok, "myaddr") == 0) {
@@ -1303,7 +1305,7 @@ parse_route_params(struct chroute *rt, u_short addr)
       }
       rt->rt_myaddr = sval;
       add_mychaddr(sval);
-#if 0
+#if 0				// don't allow type, it's static
     } else if (strcasecmp(tok, "type") == 0) {
       tok = strtok(NULL," \t\r\n");
       if (strcasecmp(tok, "direct") == 0) {
@@ -1356,7 +1358,7 @@ parse_route_params(struct chroute *rt, u_short addr)
 	if (strcasecmp(tok, "chudp") == 0)
 	  rt->rt_link = LINK_CHUDP;
       else {
-	fprintf(stderr,"bad cost %s for link to %#o\n", tok, addr);
+	fprintf(stderr,"bad link type %s for link to %#o\n", tok, addr);
 	return -1;
       }
     } else {

--- a/src/cbridge.c
+++ b/src/cbridge.c
@@ -852,33 +852,38 @@ forward_chaos_pkt_on_route(struct chroute *rt, u_char *data, int dlen)
 void 
 forward_chaos_broadcast_on_route(struct chroute *rt, int sn, u_char *data, int dlen) 
 {
-  u_char copy[CH_PK_MAXLEN];
-  struct chaos_header *ch = (struct chaos_header *)data;
-  u_char mask[32];
-  memset(mask, 0, sizeof(mask));
-  htons_buf((u_short *)&data[CHAOS_HEADERSIZE], (u_short *)mask, ch_ackno(ch));
-  if (verbose) fprintf(stderr,"Forwarding %s (fc %d) from %#o to subnet %#o on %#o bridge/subnet %#o (%s)\n",
-		       ch_opcode_name(ch_opcode(ch)),
-		       ch_fc(ch),
-		       ch_srcaddr(ch),
-		       sn, rt->rt_dest, rt->rt_braddr,
-		       rt_linkname(rt->rt_link));
+  if (RT_DOWNP(rt)) { // is there really somewhere to send it?
+    // @@@@ This should be handled differently. Let the route be NOPATH and update it when the link to the bridge comes up.
+    if (verbose) fprintf(stderr,"Not forwarding pkt: route is not up (no dest or bridge)\n");
+  } else {
+    u_char copy[CH_PK_MAXLEN];
+    struct chaos_header *ch = (struct chaos_header *)data;
+    u_char mask[32];
+    memset(mask, 0, sizeof(mask));
+    htons_buf((u_short *)&data[CHAOS_HEADERSIZE], (u_short *)mask, ch_ackno(ch));
+    if (verbose) fprintf(stderr,"Forwarding %s (fc %d) from %#o to subnet %#o on %#o bridge/subnet %#o (%s)\n",
+			 ch_opcode_name(ch_opcode(ch)),
+			 ch_fc(ch),
+			 ch_srcaddr(ch),
+			 sn, rt->rt_dest, rt->rt_braddr,
+			 rt_linkname(rt->rt_link));
 #if 0
-  // @@@@ instead: clear bit N when receiving from subnet link for N
-  // clear bit if we're sending to a subnet link,
-  // but if it's a host link, keep it and let the other end resend it if it has further host links to that subnet
-  if (RT_SUBNETP(rt) && (sn < ch_ackno(ch)*8)) {
-    mask[sn/8] = mask[sn/8] & ~(1<<(sn % 8));
-    ntohs_buf((u_short *)mask, (u_short *)&data[CHAOS_HEADERSIZE], ch_ackno(ch));
-  }
+    // @@@@ instead: clear bit N when receiving from subnet link for N
+    // clear bit if we're sending to a subnet link,
+    // but if it's a host link, keep it and let the other end resend it if it has further host links to that subnet
+    if (RT_SUBNETP(rt) && (sn < ch_ackno(ch)*8)) {
+      mask[sn/8] = mask[sn/8] & ~(1<<(sn % 8));
+      ntohs_buf((u_short *)mask, (u_short *)&data[CHAOS_HEADERSIZE], ch_ackno(ch));
+    }
 #endif
-  // forward
-  PTLOCKN(linktab_lock,"linktab_lock");
-  linktab[rt->rt_dest >>8 ].pkt_out++;
-  PTUNLOCKN(linktab_lock,"linktab_lock");
-  // send a copy, since it may be swapped in the process of sending
-  memcpy(copy, data, dlen);
-  forward_chaos_pkt_on_route(rt, copy, dlen);
+    // forward
+    PTLOCKN(linktab_lock,"linktab_lock");
+    linktab[rt->rt_dest >>8 ].pkt_out++;
+    PTUNLOCKN(linktab_lock,"linktab_lock");
+    // send a copy, since it may be swapped in the process of sending
+    memcpy(copy, data, dlen);
+    forward_chaos_pkt_on_route(rt, copy, dlen);
+  }
 }
 
 
@@ -1118,8 +1123,13 @@ void send_rut_pkt(struct chroute *rt, u_char *pkt, int c)
 
   if (rt->rt_link == LINK_NOLINK) {
     if (debug) fprintf(stderr,"%%%% Not sending RUT on %s link to %#o\n",
-		       rt_typename(rt->rt_link), rt->rt_dest);
+		       rt_linkname(rt->rt_link), rt->rt_dest);
     return;			/* ignore */
+  } else if (RT_DOWNP(rt)) {
+    // @@@@ This should be handled differently. Let the route be NOPATH and update it when the link to the bridge comes up.
+    if (debug) fprintf(stderr,"%%%% Not sending RUT on %s link: no dest or bridge address (yet)\n",
+		       rt_linkname(rt->rt_link));
+    return;
   }
   // Destination of RUT packets should always be 0
   set_ch_destaddr(cha, 0);	/* broadcast */
@@ -1154,7 +1164,8 @@ rut_sender(void *v)
     /* Send to all subnets which are not through a bridge */
     for (i = 0; i < 256; i++) {
       struct chroute *rt = &rttbl_net[i];
-      if ((rt->rt_type != RT_NOPATH) && RT_DIRECT(rt)) {
+      if ((rt->rt_type != RT_NOPATH) && RT_DIRECT(rt)
+	  && !RT_DOWNP(rt)) {
 	if (debug) fprintf(stderr,"Making RUT pkt for net %#o\n", i);
 	if ((c = make_routing_table_pkt(i<<8, &pkt[0], sizeof(pkt))) > 0) {
 	  send_rut_pkt(rt, pkt, c);
@@ -1165,7 +1176,8 @@ rut_sender(void *v)
     /* And to all individual hosts */
     for (i = 0; i < rttbl_host_len; i++) {
       struct chroute *rt = &rttbl_host[i];
-      if ((rt->rt_type != RT_NOPATH) && RT_DIRECT(rt)) {
+      if ((rt->rt_type != RT_NOPATH) && RT_DIRECT(rt)
+	  && !RT_DOWNP(rt)) {
 	if (debug) fprintf(stderr,"Making RUT pkt for link %d bridge %#o dest %#o => %#o\n", i,
 			     rt->rt_braddr, rt->rt_dest,
 			     rt->rt_braddr == 0 ? rt->rt_dest : rt->rt_braddr);
@@ -1211,6 +1223,12 @@ void send_chaos_pkt(u_char *pkt, int len)
   if (ch_srcaddr(cha) == 0)
     set_ch_srcaddr(cha, (rt->rt_myaddr == 0 ? mychaddr[0] : rt->rt_myaddr));
 
+  if (RT_DOWNP(rt)) {
+    // @@@@ This should be handled differently. Let the route be NOPATH and update it when the link to the bridge comes up.
+    if (debug) fprintf(stderr,"Can't send pkt to %#o: no dest or bridge addr in route (yet)\n", dchad);
+    return;
+  }
+
   if (verbose) fprintf(stderr,"Sending pkt %#x (%s) from me (%#o) to %#o (pkt dest %#o) %s dest %#o %s bridge %#o myaddr %#o\n",
 		       ch_packetno(cha), ch_opcode_name(ch_opcode(cha)),
 		       ch_srcaddr(cha), dchad,
@@ -1238,6 +1256,7 @@ parse_route_params(struct chroute *rt, u_short addr)
   rt->rt_cost = RTCOST_ETHER;	/* default */
   rt->rt_link = LINK_NOLINK;
 
+#if 0				// allow (subnet) routes where the bridge is not (yet) reachable
   struct chroute *brt = find_in_routing_table(rt->rt_braddr, 1, 1);
   if (brt != NULL) {
     rt->rt_link = brt->rt_link;
@@ -1268,6 +1287,7 @@ parse_route_params(struct chroute *rt, u_short addr)
 	    "%%%% No route added! Try to reorder your config - put \"route\" definitions after \"link\" definitions.\n",
 	    rt->rt_dest, rt->rt_braddr);
   }
+#endif
 
   while ((tok = strtok(NULL, " \t\r\n")) != NULL) {
     if (strcasecmp(tok, "myaddr") == 0) {
@@ -1307,6 +1327,29 @@ parse_route_params(struct chroute *rt, u_short addr)
 	rt->rt_cost = RTCOST_ETHER;
       else if (strcasecmp(tok, "asynch") == 0)
 	rt->rt_cost = RTCOST_ASYNCH;
+      else {
+	fprintf(stderr,"bad cost %s for link to %#o\n", tok, addr);
+	return -1;
+      }
+    } else if (strcasecmp(tok, "link") == 0) {
+      tok = strtok(NULL," \t\r\n");
+#ifdef CHAOS_TLS
+      if (strcasecmp(tok, "tls") == 0)
+	rt->rt_link = LINK_TLS;
+      else 
+#endif
+#ifdef CHAOS_IP
+	if (strcasecmp(tok, "ip") == 0)
+	  rt->rt_link = LINK_IP;
+      else
+#endif
+#ifdef CHAOS_ETHERP
+	if (strcasecmp(tok, "ether") == 0)
+	  rt->rt_link = LINK_ETHER;
+      else
+#endif
+	if (strcasecmp(tok, "chudp") == 0)
+	  rt->rt_link = LINK_CHUDP;
       else {
 	fprintf(stderr,"bad cost %s for link to %#o\n", tok, addr);
 	return -1;
@@ -1383,6 +1426,11 @@ parse_route_config()
 
   if (parse_route_params(rt, addr) < 0)
     return -1;
+  if (debug || verbose) {
+    printf("Added route: %s to dest %#o bridge %#o type %s link %s myaddr %#o cost %#o\n",
+	   subnetp ? "subnet" : "host", rt->rt_dest, rt->rt_braddr, rt_typename(rt->rt_type), rt_linkname(rt->rt_link),
+	   rt->rt_myaddr, rt->rt_cost);
+  }
   return 0;
 }
 
@@ -1472,8 +1520,9 @@ parse_link_args(struct chroute *rt, u_short addr)
   return 0;
 }
 
+// The sa arg can be a single sockaddr, or if multiple_addrs>0, the first of an array of sockaddrs
 static int
-parse_ip_params(char *type, struct sockaddr *sa, int default_port, char *nameptr, int nameptr_len)
+parse_ip_params(char *type, struct sockaddr *sa, int default_port, char *nameptr, int nameptr_len, int multiple_addrs)
 {
   char *tok;
   int res;
@@ -1482,6 +1531,8 @@ parse_ip_params(char *type, struct sockaddr *sa, int default_port, char *nameptr
   struct addrinfo *he, hints;
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
+  hints.ai_protocol = IPPROTO_IP; // any IP version @@@@ maybe let this be an arg?
+  hints.ai_socktype = SOCK_DGRAM; // ask for UDP to avoid getting duplicates for UDP+TCP
 #ifdef AI_ADDRCONFIG		// Use AI_ADDRCONFIG if appropriate
 #ifdef AI_MASK			// and it is a valid flag
   if (AI_MASK & AI_ADDRCONFIG)
@@ -1523,23 +1574,33 @@ parse_ip_params(char *type, struct sockaddr *sa, int default_port, char *nameptr
   }
 
   if ((res = getaddrinfo(tok, NULL, &hints, &he)) == 0) {
-    sa->sa_family = he->ai_family;
-    if (he->ai_family == AF_INET) {
-      struct sockaddr_in *s = (struct sockaddr_in *)he->ai_addr;
-      struct sockaddr_in *sin = (struct sockaddr_in *)sa;
-      sin->sin_port = htons(port);
-      memcpy(&sin->sin_addr, &s->sin_addr, sizeof(struct in_addr));
-    } else if (he->ai_family == AF_INET6) {
-      struct sockaddr_in6 *s = (struct sockaddr_in6 *)he->ai_addr;
-      struct sockaddr_in6 *sin = (struct sockaddr_in6 *)sa;
-      sin->sin6_port = htons(port);
-      memcpy(&sin->sin6_addr, &s->sin6_addr, sizeof(struct in6_addr));
-    } else {
-      fprintf(stderr,"error parsing %s host %s: unknown address family %d\n",
-	      type, tok, he->ai_family);
-      return -1;
+    int nparsed = 0;
+    do {
+      sa->sa_family = he->ai_family;
+      if (he->ai_family == AF_INET) {
+	struct sockaddr_in *s = (struct sockaddr_in *)he->ai_addr;
+	struct sockaddr_in *sin = (struct sockaddr_in *)sa;
+	sin->sin_port = htons(port);
+	memcpy(&sin->sin_addr, &s->sin_addr, sizeof(struct in_addr));
+      } else if (he->ai_family == AF_INET6) {
+	struct sockaddr_in6 *s = (struct sockaddr_in6 *)he->ai_addr;
+	struct sockaddr_in6 *sin = (struct sockaddr_in6 *)sa;
+	sin->sin6_port = htons(port);
+	memcpy(&sin->sin6_addr, &s->sin6_addr, sizeof(struct in6_addr));
+      } else {
+	fprintf(stderr,"error parsing %s host %s: unknown address family %d\n",
+		type, tok, he->ai_family);
+	return -1;
+      }
+      he = he->ai_next;
+      sa++;
+      multiple_addrs--;
+      nparsed++;
     }
+    // If we should parse multiple addresses, go on
+    while ((he != NULL) && (multiple_addrs > 0));
     strncpy(nameptr, tok, nameptr_len);
+    return nparsed;
   } else {
     if (sep != NULL)
       *sep = sepchar;		/* put separator back for error messages */
@@ -1574,7 +1635,7 @@ parse_link_config()
     rt->rt_cost_updated = time(NULL);
 
     if (parse_ip_params("chudp", &chudpdest[chudpdest_len].chu_sa.chu_saddr, CHUDP_PORT,
-			(char *)&chudpdest[chudpdest_len].chu_name, CHUDPDEST_NAME_LEN) < 0)
+			(char *)&chudpdest[chudpdest_len].chu_name, CHUDPDEST_NAME_LEN, 0) < 0)
       return -1;
     // @@@@ don't do it separately for ipv6/v4
     if (chudpdest[chudpdest_len].chu_sa.chu_saddr.sa_family == AF_INET)
@@ -1605,9 +1666,12 @@ parse_link_config()
     rt->rt_cost = RTCOST_ASYNCH;
     rt->rt_cost_updated = time(NULL);
 
-    if (parse_ip_params("tls", &tlsdest[tlsdest_len].tls_sa.tls_saddr, CHAOS_TLS_PORT,
-			(char *)&tlsdest[tlsdest_len].tls_name, TLSDEST_NAME_LEN) < 0)
+    // allow more than one address
+    int np = parse_ip_params("tls", &tlsdest[tlsdest_len].tls_saddr[0], CHAOS_TLS_PORT,
+			     (char *)&tlsdest[tlsdest_len].tls_name, TLSDEST_NAME_LEN, TLSDEST_MAX);
+    if (np < 0)
       return -1;
+    tlsdest[tlsdest_len].tls_n_saddr = np;
     do_tls = 1;
     tlsdest_len++;
 #endif // CHAOS_TLS
@@ -1620,7 +1684,7 @@ parse_link_config()
     rt->rt_cost_updated = time(NULL);
 
     if (parse_ip_params("chip", &chipdest[chipdest_len].chip_sa.chip_saddr, 0,
-			(char *)&chipdest[chipdest_len].chip_name, CHIPDEST_NAME_LEN) < 0)
+			(char *)&chipdest[chipdest_len].chip_name, CHIPDEST_NAME_LEN, 0) < 0)
       return -1;
     do_chip = 1;
     chipdest_len++;
@@ -1647,6 +1711,7 @@ parse_link_config()
   if ((rt->rt_link == LINK_TLS) && (strcasecmp(tok, "unknown") == 0)) {
     addr = 0;
     rt->rt_dest = 0;
+    rt->rt_dwild = 1;		// note this so rt_dest can be restored to 0 when link goes down
   } else {
 #endif
     if (sscanf(tok,"%ho",&addr) != 1) {
@@ -1715,24 +1780,25 @@ parse_link_config()
       } else
 	found = 0;		// look for next mux address
     }
-    if ((addr != 0) && ((addr >> 8) != (rt->rt_myaddr >> 8))) {
+    if ((addr != 0) && ((addr >> 8) != (rt->rt_myaddr >> 8))) { // note: 0 is OK for "unknown" addresses
       fprintf(stderr,"Error: TLS destination address %o must be on same subnet as TLS \"myaddr\" %o\n",
 	      addr, rt->rt_myaddr);
 	return -1;
     }
     tlsdest[tlsdest_len - 1].tls_addr = addr;
+    if (addr == 0) tlsdest[tlsdest_len - 1].tls_dwild = 1; // remember it's a "wild" address (cf tls_connector)
     tlsdest[tlsdest_len - 1].tls_myaddr = rt->rt_myaddr;
     if (subnetp) {
       fprintf(stderr,"Error: TLS links must be to hosts, not subnets.\n"
 	      "Change\n"
-	      " link tls %s:%d subnet %o\n"
+	      " link tls %s subnet %o\n"
 	      "to\n"
-	      " link tls %s:%d host NN\n"
+	      " link tls %s host NN\n"
 	      " route subnet %o bridge NN\n"
 	      "where NN is the actual tls host\n",
-	      tlsdest[tlsdest_len -1].tls_name, ntohs(tlsdest[tlsdest_len -1].tls_sa.tls_sin.sin_port),
+	      tlsdest[tlsdest_len -1].tls_name, 
 	      addr,
-	      tlsdest[tlsdest_len -1].tls_name, ntohs(tlsdest[tlsdest_len -1].tls_sa.tls_sin.sin_port),
+	      tlsdest[tlsdest_len -1].tls_name, 
 	      addr);
       return -1;
     }

--- a/src/cbridge.c
+++ b/src/cbridge.c
@@ -402,6 +402,7 @@ char *rt_linkname(u_char linktype)
 #if CHAOS_ETHERP
   case LINK_ETHER: return "Ether";
 #endif
+  case LINK_NOLINK: return "[no link]";
   default: return "Unknown?";
   }
 }

--- a/src/cbridge.h
+++ b/src/cbridge.h
@@ -148,6 +148,9 @@ typedef enum linktype {
 // Route configuration entry
 struct chroute {
   u_short rt_dest;		/* destination addr (subnet<<8 or host) - NOT redundant for subnets, we might not know the index in rttbl_host */
+#if CHAOS_TLS
+  int rt_dwild;			// destination is initially "wild", unspecific
+#endif
   u_short rt_braddr;		/* bridge address */
   u_short rt_myaddr;		/* my specific address (on that subnet), or use mychaddr */
   rttype_t rt_type;		/* connection type */
@@ -164,6 +167,7 @@ struct chroute {
 #define RT_DIRECT(rt) ((rt)->rt_braddr == 0)
 #define RT_SUBNETP(rt) (((rt)->rt_dest & 0xff) == 0)
 #define RT_PATHP(rt) ((rt)->rt_type != RT_NOPATH)
+#define RT_DOWNP(rt) (((rt)->rt_dest == 0) && ((rt)->rt_braddr == 0))
 
 // STATUS protocol, MIT AIM 628.
 // Info on this host's direct connection to a subnet. 
@@ -210,14 +214,13 @@ struct chudest {
 // here is a TLS destination
 struct tls_dest {
   u_short tls_addr;		/* remote chaos address */
+  int tls_dwild;	// destination is initially "wild", unspecific
   u_short tls_myaddr;		/* my address on this link */
   char tls_name[TLSDEST_NAME_LEN]; /* name given in (client) config or from CN (in servers) */
   int tls_serverp; /* 1 if server end - don't bother with mutex/cond stuff */
-  union {			/* The IP of the other end */
-    struct sockaddr tls_saddr;	/* generic sockaddr */
-    struct sockaddr_in tls_sin;	/* IP addr */
-    struct sockaddr_in6 tls_sin6;  /* IPv6 addr */
-  } tls_sa;
+  // @@@@ do this for chudp and chip too?
+  struct sockaddr tls_saddr[TLSDEST_MAX]; /* generic sockaddr for the IP v4/v6 addresses of the other end */
+  int tls_n_saddr;
   pthread_mutex_t tcp_reconnect_mutex;  /* would you please reconnect me? */
   pthread_cond_t tcp_reconnect_cond;
   int tls_sock;			/* TCP socket */

--- a/src/cbridge.h
+++ b/src/cbridge.h
@@ -215,6 +215,7 @@ struct chudest {
 struct tls_dest {
   u_short tls_addr;		/* remote chaos address */
   int tls_dwild;	// destination is initially "wild", unspecific
+  u_short tls_port;	// port to use
   u_short tls_myaddr;		/* my address on this link */
   char tls_name[TLSDEST_NAME_LEN]; /* name given in (client) config or from CN (in servers) */
   int tls_serverp; /* 1 if server end - don't bother with mutex/cond stuff */

--- a/src/chtls.c
+++ b/src/chtls.c
@@ -519,6 +519,7 @@ void print_tlsdest_config()
 	   tlsdest[i].tls_name,
 	   tlsdest[i].tls_myaddr);
     if (tlsdest[i].tls_serverp) printf("(server) ");
+    if (tlsdest[i].tls_sock > 0) printf("[connected] ");
     // could be more than one addr
     printf("port %d ", ntohs(tlsdest[i].tls_port));
     for (j = 0; j < tlsdest[i].tls_n_saddr; j++) {

--- a/src/chtls.c
+++ b/src/chtls.c
@@ -1212,9 +1212,9 @@ static void tls_please_reopen_tcp(struct tls_dest *td, int inputp)
       rt->rt_type = RT_NOPATH;
     }
     else if (tls_debug) fprintf(stderr,"TLS please reopen: can't find route for %#o to disable!\n", td->tls_addr);
-    // need to also disable network routes this is a bridge for
+    // need to also disable dynamic network routes this is a bridge for
     for (i = 0; i < 0xff; i++) {
-      if ((rttbl_net[i].rt_link == LINK_TLS) && (rttbl_net[i].rt_braddr == chaddr))
+      if ((rttbl_net[i].rt_link == LINK_TLS) && (rttbl_net[i].rt_braddr == chaddr) && (rttbl_net[i].rt_type != RT_STATIC))
 	rttbl_net[i].rt_type = RT_NOPATH;
     }
     // and multiplexed routes

--- a/src/chtls.c
+++ b/src/chtls.c
@@ -196,7 +196,7 @@ void reparse_tls_names(void)
     if ((tlsdest[i].tls_name[0] != '\0') // have a name
 	&& (inet_aton(tlsdest[i].tls_name, &in) == 0) // it's not an explicit v4 addr
 	&& (inet_pton(AF_INET6, tlsdest[i].tls_name, &in6) == 0)) { // and not an explicit v6 addr
-      if (tls_debug) fprintf(stderr,"tls: reparsing destination %s\n", tlsdest[i].tls_name);
+      // if (tls_debug) fprintf(stderr,"tls: reparsing destination %s\n", tlsdest[i].tls_name);
       struct sockaddr *sa = &tlsdest[i].tls_saddr[0];
       int max_addr = sizeof(tlsdest[i].tls_saddr)/sizeof(struct sockaddr);
       int nparsed = 0;
@@ -237,7 +237,7 @@ void reparse_tls_names(void)
 			       tlsdest[i].tls_name, nparsed, tlsdest[i].tls_n_saddr);
 	tlsdest[i].tls_n_saddr = nparsed;
       }
-    } else if (tls_debug) fprintf(stderr,"tls: not reparsing tls dest %s\n", tlsdest[i].tls_name);
+    } // else if (tls_debug) fprintf(stderr,"tls: not reparsing tls dest %s\n", tlsdest[i].tls_name);
   }
   PTUNLOCKN(tlsdest_lock,"tlsdest_lock");
 }

--- a/src/chtls.c
+++ b/src/chtls.c
@@ -1352,19 +1352,19 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
     return 0;
   } else if (cnt != 2) {
     if (tls_debug)
-      fprintf(stderr,"TLS read record: record len not 2: %d\n", cnt);
+      fprintf(stderr,"TLS read record (%s): record len not 2: %d\n", td->tls_name, cnt);
     return 0;
   }
   rlen = reclen[0] << 8 | reclen[1]; //ntohs(reclen[0] << 8 || reclen[1]);
   if (rlen == 0) {
     if (tls_debug)
-      fprintf(stderr,"TLS read record: MARK read (no data)\n");
+      fprintf(stderr,"TLS read record (%s): MARK read (no data)\n", td->tls_name);
     return 0;
   }
   if (tls_debug > 1)
     fprintf(stderr,"TLS read record: record len %d\n", rlen);
   if (rlen > blen) {
-    fprintf(stderr,"TLS read record: record too long for buffer: %d > %d\n", rlen, blen);
+    fprintf(stderr,"TLS read record (%s): record too long for buffer: %d > %d\n", td->tls_name, rlen, blen);
     tls_please_reopen_tcp(td, 1);
     return -1;
   }
@@ -1372,7 +1372,7 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
   PTLOCKN(tlsdest_lock,"tlsdest_lock");
   if ((ssl = td->tls_ssl) == NULL) {
     PTUNLOCKN(tlsdest_lock,"tlsdest_lock");
-    if (tls_debug) fprintf(stderr,"TLS read record: SSL is null, please reopen\n");
+    if (tls_debug) fprintf(stderr,"TLS read record (%s): SSL is null, please reopen\n", td->tls_name);
     tls_please_reopen_tcp(td, 1);
     return 0;
   }
@@ -1386,7 +1386,7 @@ tls_read_record(struct tls_dest *td, u_char *buf, int blen)
   }
   if (actual < rlen) {
     if (tls_debug)
-      fprintf(stderr,"TLS read record: read less than record: %d < %d\n", actual, rlen);
+      fprintf(stderr,"TLS read record (%s): read less than record: %d < %d\n", td->tls_name, actual, rlen);
     // read the remaining data
     int p = actual;
     while (rlen - p > 0) {

--- a/src/chudp.c
+++ b/src/chudp.c
@@ -98,7 +98,6 @@ void reparse_chudp_names()
   hi.ai_family = PF_UNSPEC;
   hi.ai_flags = AI_ADDRCONFIG;
 
-  // @@@@ also reparse TLS hosts?
   PTLOCKN(chudp_lock,"chudp_lock");
   for (i = 0; i < chudpdest_len; i++) {
     if (chudpdest[i].chu_name[0] != '\0'  /* have a name */

--- a/src/contacts.c
+++ b/src/contacts.c
@@ -50,6 +50,9 @@ static struct rfc_handler mycontacts[] = {
   { NULL, NULL}			/* end marker */
 };
 
+// @@@@ Also make RUT and DUMP-ROUTING-TABLE do the right thing.
+// @@@@ I.e. not announce the subnet route until the host link to the bridge is up, but then announce it.
+
 // Make a RUT pkt for someone (dest), filtering out its own subnet and nets it is the bridge for already.
 int
 make_routing_table_pkt(u_short dest, u_char *pkt, int pklen)

--- a/src/contacts.c
+++ b/src/contacts.c
@@ -20,6 +20,9 @@
 
 extern time_t boottime;
 extern char myname[32];
+#if CHAOS_TLS
+extern int do_tls_server;
+#endif
 
 // RFC handler struct (the contacts this process handles)
 struct rfc_handler {
@@ -49,9 +52,6 @@ static struct rfc_handler mycontacts[] = {
 #endif
   { NULL, NULL}			/* end marker */
 };
-
-// @@@@ Also make RUT and DUMP-ROUTING-TABLE do the right thing.
-// @@@@ I.e. not announce the subnet route until the host link to the bridge is up, but then announce it.
 
 // Make a RUT pkt for someone (dest), filtering out its own subnet and nets it is the bridge for already.
 int
@@ -88,7 +88,8 @@ make_routing_table_pkt(u_short dest, u_char *pkt, int pklen)
 	       && (((rttbl_net[i].rt_braddr >> 8) == (dest >> 8)) &&
 		   !directdestp &&
 		   // and we have a host route to the bridge
-		   ((hostpath = find_in_routing_table(rttbl_net[i].rt_braddr, 1, 0)) == NULL))
+		   (((hostpath = find_in_routing_table(rttbl_net[i].rt_braddr, 1, 0)) == NULL)
+		    || (hostpath->rt_dest == 0))) // which is connected
 	       ))
 	) {
       if (is_private_subnet(i)) {
@@ -149,13 +150,20 @@ make_dump_routing_table_pkt(u_char *pkt, int pklen)
 
   PTLOCKN(rttbl_lock,"rttbl_lock");
   for (sub = 0; (sub < 0xff) && (sub <= maxroutes); sub++) {
-    struct chroute *rt = &rttbl_net[sub];
+    struct chroute *hostr, *rt = &rttbl_net[sub];
     if (is_private_subnet(sub)) {
       if (debug || verbose) 
 	fprintf(stderr," NOT adding routing for private subnet %#o\n", sub);
       continue;
     }
-    if (rt->rt_type != RT_NOPATH) {
+    if ((rt->rt_type != RT_NOPATH) &&
+#if CHAOS_TLS
+	(rt->rt_type == RT_STATIC) && (rt->rt_link == LINK_TLS) // manually configured TLS route
+	? ((rt->rt_braddr != 0) // using a bridge 
+	   // with a host route which is up/connected
+	   && ((hostr = find_in_routing_table(rt->rt_braddr,1,0)) != 0) && (hostr->rt_dest != 0)) : 
+#endif
+	 1) {
       // Method: if < 0400: interface number; otherwise next hop address
       if (RT_DIRECT(rt) || (is_mychaddr(rt->rt_braddr))) {
 	// interface nr - use link type
@@ -171,6 +179,26 @@ make_dump_routing_table_pkt(u_char *pkt, int pklen)
     }
   }
   PTUNLOCKN(rttbl_lock,"rttbl_lock");
+#if CHAOS_TLS
+  // Now check if we're a tls server and have active tls links to us, for a subnet we didn't already note above
+  if (do_tls_server) {
+    PTLOCKN(tlsdest_lock,"tlsdest_lock");
+    for (int i = 0; i < tlsdest_len; i++) {
+      struct tls_dest *td = &tlsdest[i];
+      sub = (td->tls_addr >> 8);
+      if (sub >= maxroutes)
+	continue;		// skip it if it doesn't fit
+      if ((td->tls_serverp == 1) && (td->tls_addr != 0) && (data[sub*2] == 0)) {
+	if (debug) fprintf(stderr," Adding TLS server subnet %#o\n", sub);
+	data[sub*2] = htons(LINK_TLS); // method: interface number
+	data[sub*2+1] = htons(RTCOST_ASYNCH); // cost: asynch
+	if (sub > nroutes)
+	  nroutes = sub;
+      }
+    }
+    PTUNLOCKN(tlsdest_lock,"tlsdest_lock");
+  }
+#endif
 
   if (debug) fprintf(stderr," Max net in pkt %#o, i.e. %d bytes data\n", nroutes, (nroutes+1)*4);
   return (nroutes+1)*4;


### PR DESCRIPTION
Until recently, the Global Chaosnet has used a "central hub" for subnet 6, which ties together all the other subnets. This has periodically been problematic, e.g. when there were hardware problems or the hub moved or changed addresses. Using a central hub is also contradictory to the Chaosnet principle of "no central control" (see https://chaosnet.net/amber.html#Introduction).

Finally the dependence on a central hub has been removed. Since a few weeks, Eric and I are both acting as "hubs" for the Global Chaosnet, i.e., we are both accepting TLS connections from other cbridges (with the appropriate certs). In the DNS, "router.chaosnet.net" now has two addresses.

On the client side, if you use the recommended configuration:

link tls router.chaosnet.net host unknown myaddr NNNN

(where NNNN is your chaosnet address on subnet 6), the IP address you connect to might already now vary between restarts of cbridge. (The "host unknown" setting was introduced on June 18 and makes the client pick up the server chaosnet address from the certificate it presents.)

If you update your copy of cbridge and restart it, it will find all addresses of "router.chaosnet.net" and try them successively until it gets a connection. So if one of the "hub" cbridges is down for some reason, you will quickly connect to the other, without needing to restart your cbridge.