### PR TITLE
Pick optimal address for BRD

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,4 +2,5 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((c-mode . ((comment-start . "// ")
-	    (comment-end . ""))))
+	    (comment-end . "")
+	    (indent-tabs-mode nil))))

--- a/src/cbridge.c
+++ b/src/cbridge.c
@@ -328,7 +328,7 @@ myaddr_for_subnet_mask(u_short candidate, u_char *mask, int masksize)
       if ((sn < masksize) && (mask[sn/8] & (1<<(sn % 8)))) {
         // then pick it
         candidate = mychaddr[i];
-	break;
+        break;
       }
     }
   }

--- a/src/cbridge.c
+++ b/src/cbridge.c
@@ -308,6 +308,33 @@ u_short find_my_closest_addr(u_short addr)
   return mychaddr[0];
 }
 
+// If the candidate (sender) address is not on a requested subnet,
+// but I have an address on a/the requested one, use that instead
+u_short
+myaddr_for_subnet_mask(u_short candidate, u_char *mask, int masksize)
+{
+  if (nchaddr == 1) 
+    return candidate;
+  if (mask == NULL)		// illegal, but...
+    return candidate;
+
+  u_int sn = candidate>>8;
+  if ((sn >= masksize) // sn can't be in mask, or
+      || !(mask[sn/8] & (1<<(sn % 8)))) { // it fits, but isn't set
+    // Find an address which is in the one of the subnets in the mask
+    for (int i = 0; i < nchaddr; i++) {
+      sn = mychaddr[i]>>8;
+      // check if this one fits in the mask and is set
+      if ((sn < masksize) && (mask[sn/8] & (1<<(sn % 8)))) {
+        // then pick it
+        candidate = mychaddr[i];
+	break;
+      }
+    }
+  }
+  return candidate;
+}
+
 void add_mychaddr(u_short addr)
 {
   if (!is_mychaddr(addr)) {

--- a/src/cbridge.h
+++ b/src/cbridge.h
@@ -306,6 +306,7 @@ int is_mychaddr(u_short addr);
 int mychaddr_on_net(u_short addr);
 u_short find_closest_addr(u_short addrs[], int naddrs);
 u_short find_my_closest_addr(u_short addr);
+u_short myaddr_for_subnet_mask(u_short candidate, u_char *mask, int masksize);
 void add_mychaddr(u_short addr);
 int valid_chaos_host_address(u_short addr);
 int is_private_subnet(u_short subnet);

--- a/src/contacts.c
+++ b/src/contacts.c
@@ -59,8 +59,7 @@ static u_short
 brd_response_addr(u_char *rfc, int len)
 {
   struct chaos_header *ch = (struct chaos_header *)rfc;
-  u_short src = ch_srcaddr(ch);
-  u_short dst = ch_destaddr(ch);
+  u_short dst, src = ch_srcaddr(ch);
 
   // Initial attempt: find the one closest to the sender
   if (len >= CHAOS_HEADERSIZE + ch_nbytes(ch) + CHAOS_HW_TRAILERSIZE) {
@@ -89,9 +88,9 @@ brd_response_addr(u_char *rfc, int len)
       sn = mychaddr[i]>>8;
       // check if this one fits in the mask and is set
       if ((sn < masksize) && (mask[sn/8] & (1<<(sn % 8)))) {
-	// then pick it
-	dst = mychaddr[i];
-	break;
+        // then pick it
+        dst = mychaddr[i];
+        break;
       }
     }
   }

--- a/src/contacts.c
+++ b/src/contacts.c
@@ -53,6 +53,50 @@ static struct rfc_handler mycontacts[] = {
   { NULL, NULL}			/* end marker */
 };
 
+
+// Return the "best" response address for a BRD request
+static u_short 
+brd_response_addr(u_char *rfc, int len)
+{
+  struct chaos_header *ch = (struct chaos_header *)rfc;
+  u_short src = ch_srcaddr(ch);
+  u_short dst = ch_destaddr(ch);
+
+  // Initial attempt: find the one closest to the sender
+  if (len >= CHAOS_HEADERSIZE + ch_nbytes(ch) + CHAOS_HW_TRAILERSIZE) {
+    // If there is a trailer, use it - it should be closer
+    struct chaos_hw_trailer *tr = (struct chaos_hw_trailer *)(rfc+len-CHAOS_HW_TRAILERSIZE);
+    dst = find_my_closest_addr(htons(tr->ch_hw_srcaddr));
+  } else
+    dst = find_my_closest_addr(src);
+
+  if (ch_opcode(ch) != CHOP_BRD)
+    return dst;
+
+  // Now for the overkill: check if we can find one that is "more friendly" to the recipient.
+  // This is just to make displays of BRD responses for specific subnets easier to read/understand.
+  u_int masksize = ch_ackno(ch)*8;
+  u_char mask[32];
+  // broadcast mask (unswapped)
+  htons_buf((u_short *)&rfc[CHAOS_HEADERSIZE], (u_short *)mask, ch_ackno(ch));
+  u_int sn = dst>>8;
+  if ((sn >= masksize) // sn can't be in mask, or
+      || !(mask[sn/8] & (1<<(sn % 8)))) { // it fits, but isn't set
+    // If "my closest addr" is not on a requested subnet,
+    // but I have an address on a/the requested one, use that instead
+    for (int i = 0; i < nchaddr; i++) {
+      sn = mychaddr[i]>>8;
+      // check if this one fits in the mask and is set
+      if ((sn < masksize) && (mask[sn/8] & (1<<(sn % 8)))) {
+	// then pick it
+	dst = mychaddr[i];
+	break;
+      }
+    }
+  }
+  return dst;
+}
+
 // Make a RUT pkt for someone (dest), filtering out its own subnet and nets it is the bridge for already.
 int
 make_routing_table_pkt(u_short dest, u_char *pkt, int pklen)
@@ -226,7 +270,7 @@ dump_routing_table_responder(u_char *rfc, int len)
   set_ch_destindex(ap, ch_srcindex(ch));
   if (dst == 0)
     // broadcast
-    dst = find_my_closest_addr(src);
+    dst = brd_response_addr(rfc, len);
   set_ch_srcaddr(ap, dst);
   set_ch_srcindex(ap, ch_destindex(ch));
 
@@ -276,7 +320,7 @@ uptime_responder(u_char *rfc, int len)
   set_ch_destindex(ap, ch_srcindex(ch));
   if (dst == 0)
     // broadcast
-    dst = find_my_closest_addr(src);
+    dst = brd_response_addr(rfc, len);
   set_ch_srcaddr(ap, dst);
   set_ch_srcindex(ap, ch_destindex(ch));
 
@@ -311,7 +355,7 @@ time_responder(u_char *rfc, int len)
   set_ch_destindex(ap, ch_srcindex(ch));
   if (dst == 0)
     // broadcast
-    dst = find_my_closest_addr(src);
+    dst = brd_response_addr(rfc, len);
   set_ch_srcaddr(ap, dst);
   set_ch_srcindex(ap, ch_destindex(ch));
 
@@ -341,7 +385,7 @@ status_responder(u_char *rfc, int len)
   set_ch_destindex(ap, ch_srcindex(ch));
   if (dst == 0)
     // broadcast
-    dst = find_my_closest_addr(src);
+    dst = brd_response_addr(rfc, len);
   set_ch_srcaddr(ap, dst);
   set_ch_srcindex(ap, ch_destindex(ch));
 
@@ -414,7 +458,7 @@ lastcn_responder(u_char *rfc, int len)
   set_ch_destindex(ap, ch_srcindex(ch));
   if (dst == 0)
     // broadcast
-    dst = find_my_closest_addr(src);
+    dst = brd_response_addr(rfc, len);
   set_ch_srcaddr(ap, dst);
   set_ch_srcindex(ap, ch_destindex(ch));
 

--- a/src/contacts.c
+++ b/src/contacts.c
@@ -64,13 +64,14 @@ brd_response_addr(u_char *rfc, int len)
 
   // Initial attempt: find the one closest to the sender
   if (len >= CHAOS_HEADERSIZE + ch_nbytes(ch) + CHAOS_HW_TRAILERSIZE) {
-    // If there is a trailer, use it - it should be closer
+    // If there is a trailer, use it - we'll most likely send the response in that direction
     struct chaos_hw_trailer *tr = (struct chaos_hw_trailer *)(rfc+len-CHAOS_HW_TRAILERSIZE);
     dst = find_my_closest_addr(htons(tr->ch_hw_srcaddr));
   } else
     dst = find_my_closest_addr(src);
 
-  if (ch_opcode(ch) != CHOP_BRD)
+  if ((ch_opcode(ch) != CHOP_BRD) // only BRD has mask
+      || (nchaddr == 1))   // if we have only one address just use it.
     return dst;
 
   // Now for the overkill: check if we can find one that is "more friendly" to the recipient.


### PR DESCRIPTION
Answers for RFCs are sent using the destination address as source (and v.v). Broadcast (BRD) packets, however, come with destination address 0. If you have more than one address on your cbridge, which one should you pick as sender? And when does it matter?

Answer: usually it doesn't matter, but in the case that the subnet mask of the BRD packet doesn't include all of your subnets, you should avoid using the non-included address in the response. This makes the received BRD/answer look more reasonable, e.g. in a listing of several broadcast responses (such as on http://up.dfupdate.se/cha/hinfo.py). For example, if a BRD packet includes only subnet 7, sending it or a response using an address on subnet 6 would look weird.

For cbridges with only one address, this code only adds a few instructions, so the overhead is negligible.

[22 Aug: Updated to also optimize the source address when sending BRD packets , in ncp.c]